### PR TITLE
Make the error response from register procedure more detailed

### DIFF
--- a/internal/sbi/producer/nf_management.go
+++ b/internal/sbi/producer/nf_management.go
@@ -390,11 +390,10 @@ func NFRegisterProcedure(nfProfile models.NfProfile) (header http.Header, respon
 
 	err := nrf_context.NnrfNFManagementDataModel(&nf, nfProfile)
 	if err != nil {
-		timer := fmt.Sprint(nfProfile.HeartBeatTimer)
 		problemDetails := &models.ProblemDetails{
-			Title:  nfProfile.NfInstanceId,
+			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: timer,
+			Detail: err.Error(),
 		}
 		return nil, nil, false, problemDetails
 	}


### PR DESCRIPTION
NRF only return the timer value from request as Problem detail when NnrfNFManagementDataModel return error originally.
So I change that to the error msg return from NnrfNFManagementDataModel.