### PR TITLE
Make limit parameter for GET nfInstance optional

### DIFF
--- a/internal/context/management_data.go
+++ b/internal/context/management_data.go
@@ -637,6 +637,10 @@ func GetNofificationUri(nfProfile models.NfProfile) []string {
 func NnrfUriListLimit(originalUL *UriList, limit int) {
 	// response limit
 
+	if limit <= 0 {
+		return
+	}
+
 	if limit < len(originalUL.Link.Item) {
 		var i int
 		var b *Links = new(Links)

--- a/internal/sbi/producer/nf_management.go
+++ b/internal/sbi/producer/nf_management.go
@@ -93,16 +93,21 @@ func HandleUpdateNFInstanceRequest(request *httpwrapper.Request) *httpwrapper.Re
 func HandleGetNFInstancesRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.NfmLog.Infoln("Handle GetNFInstancesRequest")
 	nfType := request.Query.Get("nf-type")
-	limit, err := strconv.Atoi(request.Query.Get("limit"))
-	if err != nil {
-		logger.NfmLog.Errorln("Error in string conversion: ", limit)
-		problemDetails := models.ProblemDetails{
-			Title:  "Invalid Parameter",
-			Status: http.StatusBadRequest,
-			Detail: err.Error(),
-		}
+	limit_param := request.Query.Get("limit")
+	limit := 0
+	if limit_param != "" {
+		var err error
+		limit, err = strconv.Atoi(request.Query.Get("limit"))
+		if err != nil {
+			logger.NfmLog.Errorln("Error in string conversion: ", limit)
+			problemDetails := models.ProblemDetails{
+				Title:  "Invalid Parameter",
+				Status: http.StatusBadRequest,
+				Detail: err.Error(),
+			}
 
-		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+			return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		}
 	}
 
 	response, problemDetails := GetNFInstancesProcedure(nfType, limit)


### PR DESCRIPTION
- is optional in the specs
- was effectively mandatory (parsing failed with 400 error when absent)