### PR TITLE
Clean up HandleAccessTokenRequest

### DIFF
--- a/internal/sbi/producer/access_token.go
+++ b/internal/sbi/producer/access_token.go
@@ -27,17 +27,19 @@ func HandleAccessTokenRequest(request *httpwrapper.Request) *httpwrapper.Respons
 
 	response, errResponse := AccessTokenProcedure(accessTokenReq)
 
-	if response != nil {
+	if errResponse != nil {
+		return httpwrapper.NewResponse(http.StatusBadRequest, nil, errResponse)
+	} else if response != nil {
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
-	} else if errResponse != nil {
-		return httpwrapper.NewResponse(http.StatusBadRequest, nil, errResponse)
 	}
+
+	logger.AccTokenLog.Errorln("AccessTokenProcedure returned neither an error nor a response")
 	problemDetails := &models.ProblemDetails{
-		Status: http.StatusForbidden,
+		Status: http.StatusInternalServerError,
 		Cause:  "UNSPECIFIED",
 	}
-	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusInternalServerError, nil, problemDetails)
 }
 
 func AccessTokenProcedure(request models.AccessTokenReq) (

--- a/internal/sbi/producer/access_token.go
+++ b/internal/sbi/producer/access_token.go
@@ -39,7 +39,7 @@ func HandleAccessTokenRequest(request *httpwrapper.Request) *httpwrapper.Respons
 		Status: http.StatusInternalServerError,
 		Cause:  "UNSPECIFIED",
 	}
-	return httpwrapper.NewResponse(http.StatusInternalServerError, nil, problemDetails)
+	return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 }
 
 func AccessTokenProcedure(request models.AccessTokenReq) (


### PR DESCRIPTION
- check for error first and for result second
- if neither error nor result is present: that is an Internal Server Error
- code worked fine before, but a change in `AccessTokenProcedure` in the future could have messed it up.