### PR TITLE
Fix possible Subscription ID collision

### DIFF
--- a/internal/context/management_data.go
+++ b/internal/context/management_data.go
@@ -1,11 +1,11 @@
 package context
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"strconv"
-	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"go.mongodb.org/mongo-driver/bson"
@@ -44,10 +44,13 @@ func NnrfNFManagementDataModel(nf *models.NfProfile, nfprofile models.NfProfile)
 	return nil
 }
 
-func SetsubscriptionId() string {
-	rand.Seed(time.Now().UnixNano())
-	x := rand.Intn(100)
-	return strconv.Itoa(x)
+func SetsubscriptionId() (string, error) {
+	buffer := make([]byte, 16)
+	_, err := rand.Read(buffer)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buffer), nil
 }
 
 func nnrfNFManagementCondition(nf *models.NfProfile, nfprofile models.NfProfile) {

--- a/internal/sbi/producer/nf_management.go
+++ b/internal/sbi/producer/nf_management.go
@@ -191,11 +191,19 @@ func CreateSubscriptionProcedure(subscription models.NrfSubscriptionData) (bson.
 	tmp, err := json.Marshal(subscription)
 	if err != nil {
 		logger.NfmLog.Errorln("Marshal error in CreateSubscriptionProcedure: ", err)
+		return nil, &models.ProblemDetails{
+			Status: http.StatusInternalServerError,
+			Cause:  "CREATE_SUBSCRIPTION_ERROR",
+		}
 	}
 	putData := bson.M{}
 	err = json.Unmarshal(tmp, &putData)
 	if err != nil {
 		logger.NfmLog.Errorln("Unmarshal error in CreateSubscriptionProcedure: ", err)
+		return nil, &models.ProblemDetails{
+			Status: http.StatusInternalServerError,
+			Cause:  "CREATE_SUBSCRIPTION_ERROR",
+		}
 	}
 
 	// TODO: need to store Condition !

--- a/internal/sbi/producer/nf_management.go
+++ b/internal/sbi/producer/nf_management.go
@@ -178,7 +178,15 @@ func HandleCreateSubscriptionRequest(request *httpwrapper.Request) *httpwrapper.
 }
 
 func CreateSubscriptionProcedure(subscription models.NrfSubscriptionData) (bson.M, *models.ProblemDetails) {
-	subscription.SubscriptionId = nrf_context.SetsubscriptionId()
+	subscriptionID, err := nrf_context.SetsubscriptionId()
+	if err != nil {
+		logger.NfmLog.Errorf("Unable to create subscription ID in CreateSubscriptionProcedure: %+v", err)
+		return nil, &models.ProblemDetails{
+			Status: http.StatusInternalServerError,
+			Cause:  "CREATE_SUBSCRIPTION_ERROR",
+		}
+	}
+	subscription.SubscriptionId = subscriptionID
 
 	tmp, err := json.Marshal(subscription)
 	if err != nil {
@@ -198,7 +206,7 @@ func CreateSubscriptionProcedure(subscription models.NrfSubscriptionData) (bson.
 			logger.NfmLog.Errorf("CreateSubscriptionProcedure err: %+v", err)
 		}
 		problemDetails := &models.ProblemDetails{
-			Status: http.StatusBadRequest,
+			Status: http.StatusInternalServerError,
 			Cause:  "CREATE_SUBSCRIPTION_ERROR",
 		}
 		return nil, problemDetails


### PR DESCRIPTION
- created subscription ID was in the range of 0 to 100, leading to possible collisions
- this change changes the range to up to 2^128
- it also uses a cryptographically secure RNG (though this is probably not important here)
- I also took the liberty to address some semi-unhandled error cases