### PR TITLE
fix: restore intended behavior of nnrf-nfm/v1/nf-instances endpoint

### DIFF
--- a/internal/sbi/api_nfmanagement.go
+++ b/internal/sbi/api_nfmanagement.go
@@ -198,8 +198,8 @@ func (s *Server) HTTPUpdateNFInstance(c *gin.Context) {
 
 // GetNFInstances - Retrieves a collection of NF Instances
 func (s *Server) HTTPGetNFInstances(c *gin.Context) {
-	nfType := c.Params.ByName("nf-type")
-	limitParam := c.Params.ByName("limit")
+	nfType := c.Query("nf-type")
+	limitParam := c.Query("limit")
 
 	if nfType == "" || limitParam == "" {
 		problemDetail := &models.ProblemDetails{


### PR DESCRIPTION
The nnrf-nfm/v1/nf-instances endpoint tried to get request query parameters by extracting the from the request path using `c.Params.ByName`.

This resulted in empty results for `nfType` and `limitParam` and thus always returned 400 on every request.