### PR TITLE
fix: IPv6 nfProfile

### DIFF
--- a/internal/context/management_data.go
+++ b/internal/context/management_data.go
@@ -89,7 +89,7 @@ func nnrfNFManagementCondition(nf *models.NfProfile, nfprofile models.NfProfile)
 	if nfprofile.Ipv6Addresses != nil {
 		// fmt.Println("NsiList")
 		a := make([]string, len(nfprofile.Ipv6Addresses))
-		copy(a, nfprofile.Ipv4Addresses)
+		copy(a, nfprofile.Ipv6Addresses)
 		nf.Ipv6Addresses = a
 	}
 	// DefaultNotificationSubscription


### PR DESCRIPTION
With @linouxis9, we remarked the Free5gc *Nrf* not registered a IPv6 nfProfile, by example when we start a *Ausf*
This PR fixes it