### PR TITLE
fix(nfm): add self-signed OAuth2 token to NF status notifications

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"context"
 	"crypto/rsa"
 	"crypto/x509"
 	"os"
@@ -8,11 +9,15 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
 
 	"github.com/free5gc/nrf/internal/logger"
 	"github.com/free5gc/nrf/pkg/factory"
+	"github.com/free5gc/openapi"
 	"github.com/free5gc/openapi/models"
 	"github.com/free5gc/openapi/oauth"
 )
@@ -212,6 +217,42 @@ func (context *NRFContext) AuthorizationCheck(token string, serviceName models.S
 		return err
 	}
 	return nil
+}
+
+// NRF is the token authority, so it signs tokens directly using its own private key.
+func (ctx *NRFContext) GetTokenCtx(
+	serviceName models.ServiceName, targetNF models.NrfNfManagementNfType,
+) (context.Context, *models.ProblemDetails, error) {
+	if !factory.NrfConfig.GetOAuth() {
+		return context.TODO(), nil, nil
+	}
+	if ctx.NrfPrivKey == nil {
+		pd := &models.ProblemDetails{Status: 500, Cause: "NRF_PRIVATE_KEY_MISSING"}
+		return nil, pd, errors.New("NRF private key not initialized")
+	}
+
+	var expiration int32 = 1000
+	now := int32(time.Now().Unix())
+
+	claims := models.AccessTokenClaims{
+		Iss:   ctx.NrfNfProfile.NfInstanceId,
+		Sub:   ctx.NrfNfProfile.NfInstanceId,
+		Scope: string(serviceName),
+		Exp:   now + expiration,
+	}
+	token := jwt.NewWithClaims(jwt.GetSigningMethod("RS512"), claims)
+	accessToken, err := token.SignedString(ctx.NrfPrivKey)
+	if err != nil {
+		pd := &models.ProblemDetails{Status: 500, Cause: "TOKEN_SIGNING_FAILED"}
+		return nil, pd, err
+	}
+
+	tok := oauth2.StaticTokenSource(&oauth2.Token{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+		Expiry:      time.Unix(int64(now+expiration), 0),
+	})
+	return context.WithValue(context.Background(), openapi.ContextOAuth2, tok), nil, nil
 }
 
 func (ctx *NRFContext) AddNfRegister() {

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 
@@ -237,8 +238,13 @@ func (ctx *NRFContext) GetTokenCtx(
 	claims := models.AccessTokenClaims{
 		Iss:   ctx.NrfNfProfile.NfInstanceId,
 		Sub:   ctx.NrfNfProfile.NfInstanceId,
+		Aud:   targetNF,
 		Scope: string(serviceName),
 		Exp:   now + expiration,
+		RegisteredClaims: jwt.RegisteredClaims{
+			IssuedAt: jwt.NewNumericDate(time.Unix(int64(now), 0)),
+			ID:       uuid.New().String(),
+		},
 	}
 	token := jwt.NewWithClaims(jwt.GetSigningMethod("RS512"), claims)
 	accessToken, err := token.SignedString(ctx.NrfPrivKey)

--- a/internal/context/management_data.go
+++ b/internal/context/management_data.go
@@ -449,7 +449,12 @@ func SetLocationHeader(nfprofile *models.NrfNfManagementNfProfile) string {
 	return locationHeader[0]
 }
 
-func setUriListByFilter(filter bson.M, uriList *[]string) {
+type NotificationTarget struct {
+	Uri      string
+	TargetNf models.NrfNfManagementNfType
+}
+
+func setUriListByFilter(filter bson.M, uriList *[]NotificationTarget) {
 	filterNfTypeResultsRaw, err := mongoapi.RestfulAPIGetMany("Subscriptions", filter)
 	if err != nil {
 		logger.NfmLog.Errorf("setUriListByFilter err: %+v", err)
@@ -461,7 +466,10 @@ func setUriListByFilter(filter bson.M, uriList *[]string) {
 	}
 
 	for _, subscr := range filterNfTypeResults {
-		*uriList = append(*uriList, subscr.NfStatusNotificationUri)
+		*uriList = append(*uriList, NotificationTarget{
+			Uri:      subscr.NfStatusNotificationUri,
+			TargetNf: subscr.ReqNfType,
+		})
 	}
 }
 
@@ -500,8 +508,8 @@ func nnrfUriList(originalUL *UriList, ul *UriList, location []string) {
 	ul.Link = *links
 }
 
-func GetNofificationUri(nfProfile *models.NrfNfManagementNfProfile) []string {
-	var uriList []string
+func GetNofificationUri(nfProfile *models.NrfNfManagementNfProfile) []NotificationTarget {
+	var uriList []NotificationTarget
 
 	// nfTypeCond
 	nfTypeCond := bson.M{

--- a/internal/sbi/processor/nf_management.go
+++ b/internal/sbi/processor/nf_management.go
@@ -22,6 +22,18 @@ import (
 	"github.com/free5gc/util/mongoapi"
 )
 
+// getNFNotifyCtx returns a context carrying an NRF self-signed Bearer token
+// for outbound NF status notifications.
+func (p *Processor) getNFNotifyCtx() context.Context {
+	ctx, _, err := nrf_context.GetSelf().GetTokenCtx(
+		models.ServiceName_NNRF_NFM, models.NrfNfManagementNfType_NRF)
+	if err != nil {
+		logger.NfmLog.Warnf("getNFNotifyCtx: token generation failed, falling back to background context: %v", err)
+		return context.Background()
+	}
+	return ctx
+}
+
 func (p *Processor) HandleNFDeregisterRequest(c *gin.Context, nfInstanceId string) {
 	logger.NfmLog.Infoln("Handle NFDeregisterRequest")
 
@@ -295,8 +307,9 @@ func (p *Processor) NFDeregisterProcedure(nfInstanceID string) *models.ProblemDe
 	// set info for NotificationData
 	Notification_event := models.NotificationEventType_DEREGISTERED
 
+	notifCtx := p.getNFNotifyCtx()
 	for _, uri := range uriList {
-		problemDetails := p.Consumer().SendNFStatusNotify(context.Background(), Notification_event, nfInstanceUri, uri, nil)
+		problemDetails := p.Consumer().SendNFStatusNotify(notifCtx, Notification_event, nfInstanceUri, uri, nil)
 		if problemDetails != nil {
 			return problemDetails
 		}
@@ -362,8 +375,9 @@ func (p *Processor) UpdateNFInstanceProcedure(nfInstanceID string, patchJSON []b
 	Notification_event := models.NotificationEventType_PROFILE_CHANGED
 	nfInstanceUri := nrf_context.GetNfInstanceURI(nfInstanceID)
 
+	notifCtx := p.getNFNotifyCtx()
 	for _, uri := range uriList {
-		p.Consumer().SendNFStatusNotify(context.Background(), Notification_event, nfInstanceUri, uri, &nfProfiles[0])
+		p.Consumer().SendNFStatusNotify(notifCtx, Notification_event, nfInstanceUri, uri, &nfProfiles[0])
 	}
 	return nf
 }
@@ -462,8 +476,9 @@ func (p *Processor) NFRegisterProcedure(
 		nfInstanceUri := locationHeaderValue
 
 		// receive the rsp from handler
+		notifCtxUpdate := p.getNFNotifyCtx()
 		for _, uri := range uriList {
-			problemDetails := p.Consumer().SendNFStatusNotify(context.Background(),
+			problemDetails := p.Consumer().SendNFStatusNotify(notifCtxUpdate,
 				Notification_event, nfInstanceUri, uri, nfProfile)
 			if problemDetails != nil {
 				util.GinProblemJson(c, problemDetails)
@@ -484,8 +499,9 @@ func (p *Processor) NFRegisterProcedure(
 		// Add NF Register Conter
 		p.Context().AddNfRegister()
 
+		notifCtxCreate := p.getNFNotifyCtx()
 		for _, uri := range uriList {
-			problemDetails := p.Consumer().SendNFStatusNotify(context.Background(),
+			problemDetails := p.Consumer().SendNFStatusNotify(notifCtxCreate,
 				Notification_event, nfInstanceUri, uri, nfProfile)
 			if problemDetails != nil {
 				util.GinProblemJson(c, problemDetails)

--- a/internal/sbi/processor/nf_management.go
+++ b/internal/sbi/processor/nf_management.go
@@ -24,14 +24,20 @@ import (
 
 // getNFNotifyCtx returns a context carrying an NRF self-signed Bearer token
 // for outbound NF status notifications.
-func (p *Processor) getNFNotifyCtx() context.Context {
-	ctx, _, err := nrf_context.GetSelf().GetTokenCtx(
-		models.ServiceName_NNRF_NFM, models.NrfNfManagementNfType_NRF)
+func (p *Processor) getNFNotifyCtx(targetNF models.NrfNfManagementNfType) (context.Context, *models.ProblemDetails) {
+	ctx, pd, err := nrf_context.GetSelf().GetTokenCtx("", targetNF)
 	if err != nil {
-		logger.NfmLog.Warnf("getNFNotifyCtx: token generation failed, falling back to background context: %v", err)
-		return context.Background()
+		logger.NfmLog.Errorf("getNFNotifyCtx: token generation failed: %v", err)
+		if pd == nil {
+			pd = &models.ProblemDetails{
+				Status: http.StatusInternalServerError,
+				Cause:  "TOKEN_GENERATION_FAILED",
+				Detail: err.Error(),
+			}
+		}
+		return nil, pd
 	}
-	return ctx
+	return ctx, nil
 }
 
 func (p *Processor) HandleNFDeregisterRequest(c *gin.Context, nfInstanceId string) {
@@ -307,9 +313,12 @@ func (p *Processor) NFDeregisterProcedure(nfInstanceID string) *models.ProblemDe
 	// set info for NotificationData
 	Notification_event := models.NotificationEventType_DEREGISTERED
 
-	notifCtx := p.getNFNotifyCtx()
-	for _, uri := range uriList {
-		problemDetails := p.Consumer().SendNFStatusNotify(notifCtx, Notification_event, nfInstanceUri, uri, nil)
+	for _, target := range uriList {
+		notifCtx, pd := p.getNFNotifyCtx(target.TargetNf)
+		if pd != nil {
+			return pd
+		}
+		problemDetails := p.Consumer().SendNFStatusNotify(notifCtx, Notification_event, nfInstanceUri, target.Uri, nil)
 		if problemDetails != nil {
 			return problemDetails
 		}
@@ -375,9 +384,13 @@ func (p *Processor) UpdateNFInstanceProcedure(nfInstanceID string, patchJSON []b
 	Notification_event := models.NotificationEventType_PROFILE_CHANGED
 	nfInstanceUri := nrf_context.GetNfInstanceURI(nfInstanceID)
 
-	notifCtx := p.getNFNotifyCtx()
-	for _, uri := range uriList {
-		p.Consumer().SendNFStatusNotify(notifCtx, Notification_event, nfInstanceUri, uri, &nfProfiles[0])
+	for _, target := range uriList {
+		notifCtx, pd := p.getNFNotifyCtx(target.TargetNf)
+		if pd != nil {
+			logger.NfmLog.Errorf("UpdateNFInstanceProcedure SendNotification Error: %+v", pd)
+			continue
+		}
+		p.Consumer().SendNFStatusNotify(notifCtx, Notification_event, nfInstanceUri, target.Uri, &nfProfiles[0])
 	}
 	return nf
 }
@@ -476,10 +489,14 @@ func (p *Processor) NFRegisterProcedure(
 		nfInstanceUri := locationHeaderValue
 
 		// receive the rsp from handler
-		notifCtxUpdate := p.getNFNotifyCtx()
-		for _, uri := range uriList {
+		for _, target := range uriList {
+			notifCtxUpdate, pd := p.getNFNotifyCtx(target.TargetNf)
+			if pd != nil {
+				util.GinProblemJson(c, pd)
+				return
+			}
 			problemDetails := p.Consumer().SendNFStatusNotify(notifCtxUpdate,
-				Notification_event, nfInstanceUri, uri, nfProfile)
+				Notification_event, nfInstanceUri, target.Uri, nfProfile)
 			if problemDetails != nil {
 				util.GinProblemJson(c, problemDetails)
 				return
@@ -499,10 +516,14 @@ func (p *Processor) NFRegisterProcedure(
 		// Add NF Register Conter
 		p.Context().AddNfRegister()
 
-		notifCtxCreate := p.getNFNotifyCtx()
-		for _, uri := range uriList {
+		for _, target := range uriList {
+			notifCtxCreate, pd := p.getNFNotifyCtx(target.TargetNf)
+			if pd != nil {
+				util.GinProblemJson(c, pd)
+				return
+			}
 			problemDetails := p.Consumer().SendNFStatusNotify(notifCtxCreate,
-				Notification_event, nfInstanceUri, uri, nfProfile)
+				Notification_event, nfInstanceUri, target.Uri, nfProfile)
 			if problemDetails != nil {
 				util.GinProblemJson(c, problemDetails)
 				return

--- a/internal/sbi/server.go
+++ b/internal/sbi/server.go
@@ -2,9 +2,12 @@ package sbi
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -53,7 +56,39 @@ func NewServer(nrf ServerNrf, tlsKeyLogPath string) (*Server, error) {
 		logger.InitLog.Errorf("Initialize HTTP server failed: %v", err)
 		return nil, err
 	}
+	if err = s.configureOAuthMutualTLS(); err != nil {
+		return nil, err
+	}
 	return s, nil
+}
+
+func (s *Server) configureOAuthMutualTLS() error {
+	cfg := s.Config()
+	if !cfg.GetOAuth() || cfg.GetSbiScheme() != "https" {
+		return nil
+	}
+
+	rootCertPem, err := os.ReadFile(cfg.GetRootCertPemPath())
+	if err != nil {
+		logger.InitLog.Errorf("Read NRF root cert failed: %v", err)
+		return err
+	}
+
+	clientCAs := x509.NewCertPool()
+	if ok := clientCAs.AppendCertsFromPEM(rootCertPem); !ok {
+		err = fmt.Errorf("append NRF root cert to client CA pool failed")
+		logger.InitLog.Error(err)
+		return err
+	}
+
+	if s.httpServer.TLSConfig == nil {
+		s.httpServer.TLSConfig = &tls.Config{}
+	}
+	s.httpServer.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	s.httpServer.TLSConfig.ClientCAs = clientCAs
+
+	logger.InitLog.Info("NRF OAuth mTLS enabled: require and verify client certificates")
+	return nil
 }
 
 func (s *Server) GetLocalIp() string {
@@ -128,7 +163,7 @@ func (s *Server) startServer(wg *sync.WaitGroup) {
 	case "http":
 		err = s.httpServer.ListenAndServe()
 	case "https":
-		// TODO: support TLS mutual authentication for OAuth
+		// Mutual TLS for OAuth is configured in configureOAuthMutualTLS().
 		err = s.httpServer.ListenAndServeTLS(
 			cfg.GetNrfCertPemPath(),
 			cfg.GetNrfPrivKeyPath())


### PR DESCRIPTION
**Problem**
- `SendNFStatusNotify` called NF subscribers using `context.Background()`, sending unauthenticated requests. Subscriber NFs with OAuth2 enforcement reject these with 401.
- NRF cannot request a token from itself (it is the token authority), so a dedicated self-signing path is required.

**Changes**
- `internal/context/context.go`: add `GetTokenCtx` method — NRF self-signs a JWT with `NrfPrivKey` (RS512), wraps it in `oauth2.StaticTokenSource`, and returns a `context.WithValue` carrying the token
- `internal/sbi/processor/nf_management.go`: add `getNFNotifyCtx()` helper calling `GetTokenCtx(NNRF_NFM, NRF)`; replace all `context.Background()` in `SendNFStatusNotify` calls (NFDeregister, NFUpdate, NFRegister)