### PR TITLE
fix: NRF GET /nnrf-disc/v1/nf-instances Panic DoS

### DIFF
--- a/internal/context/dataconv.go
+++ b/internal/context/dataconv.go
@@ -1,7 +1,6 @@
 package context
 
 import (
-	"encoding/hex"
 	"fmt"
 	"math/big"
 	"net"
@@ -42,13 +41,18 @@ func Ipv4IntToIpv4String(ip int64) string {
 
 // Ipv6IntToIpv6String - Convert Ipv6 *big.Int to string
 func Ipv6IntToIpv6String(ip *big.Int) string {
-	ipv6Bytes := ip.Bytes()
-	ipv6String := hex.EncodeToString(ipv6Bytes)
-
-	for i := 1; i < 8; i++ {
-		ipv6String = ipv6String[:i-1+4*i] + ":" + ipv6String[i-1+4*i:]
+	if ip == nil || ip.Sign() < 0 {
+		return ""
 	}
-	return ipv6String
+
+	ipv6Bytes := ip.Bytes()
+	if len(ipv6Bytes) > net.IPv6len {
+		return ""
+	}
+
+	var fullIPv6 [net.IPv6len]byte
+	copy(fullIPv6[net.IPv6len-len(ipv6Bytes):], ipv6Bytes)
+	return net.IP(fullIPv6[:]).String()
 }
 
 // EncodeGroupId - Encode GroupId to number string(output pattern: [10][3][3][25])

--- a/internal/context/management_data.go
+++ b/internal/context/management_data.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
 	"strconv"
 
 	"github.com/mitchellh/mapstructure"
@@ -39,7 +40,9 @@ func NnrfNFManagementDataModel(nf *models.NrfNfManagementNfProfile, nfprofile *m
 	}
 
 	nnrfNFManagementCondition(nf, nfprofile)
-	nnrfNFManagementOption(nf, nfprofile)
+	if err := nnrfNFManagementOption(nf, nfprofile); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -99,7 +102,7 @@ func nnrfNFManagementCondition(nf *models.NrfNfManagementNfProfile, nfprofile *m
 	}
 }
 
-func nnrfNFManagementOption(nf *models.NrfNfManagementNfProfile, nfprofile *models.NrfNfManagementNfProfile) {
+func nnrfNFManagementOption(nf *models.NrfNfManagementNfProfile, nfprofile *models.NrfNfManagementNfProfile) error {
 	// sNssais
 	if nfprofile.SNssais != nil {
 		// fmt.Println("SNssais")
@@ -342,6 +345,16 @@ func nnrfNFManagementOption(nf *models.NrfNfManagementNfProfile, nfprofile *mode
 		if nfprofile.BsfInfo.Ipv6PrefixRanges != nil {
 			Ipv6Range := make([]models.NrfNfManagementIpv6PrefixRange, len(nfprofile.BsfInfo.Ipv6PrefixRanges))
 			for i := 0; i < len(nfprofile.BsfInfo.Ipv6PrefixRanges); i++ {
+				startIP := net.ParseIP(nfprofile.BsfInfo.Ipv6PrefixRanges[i].Start)
+				if startIP == nil {
+					return fmt.Errorf("invalid IPv6 prefix range start: %q",
+						nfprofile.BsfInfo.Ipv6PrefixRanges[i].Start)
+				}
+				endIP := net.ParseIP(nfprofile.BsfInfo.Ipv6PrefixRanges[i].End)
+				if endIP == nil {
+					return fmt.Errorf("invalid IPv6 prefix range end: %q",
+						nfprofile.BsfInfo.Ipv6PrefixRanges[i].End)
+				}
 				Ipv6Range[i].Start = Ipv6ToInt(nfprofile.BsfInfo.Ipv6PrefixRanges[i].Start).String()
 				Ipv6Range[i].End = Ipv6ToInt(nfprofile.BsfInfo.Ipv6PrefixRanges[i].End).String()
 			}
@@ -394,6 +407,7 @@ func nnrfNFManagementOption(nf *models.NrfNfManagementNfProfile, nfprofile *mode
 		nf.CustomInfo = make(map[string]interface{})
 	}
 	nf.CustomInfo["oauth2"] = factory.NrfConfig.GetOAuth()
+	return nil
 }
 
 func GetNfInstanceURI(nfInstID string) string {


### PR DESCRIPTION
Fix NRF GET /nnrf-disc/v1/nf-instances Panic DoS: free5gc/free5gc#946

Files: `internal/context/dataconv.go` `internal/context/management_data.go`

Problem:

- NRF discovery panicked with `slice bounds out of range [:4] with length 2` when rebuilding BSF `ipv6PrefixRanges` from the database.
- `Ipv6ToInt` stripped leading zeros, storing short decimal representations (e.g., `"::1"` stored as `"1"`).
- `Ipv6IntToIpv6String` assumed exactly 32 hex characters and manually sliced strings, panicking on short inputs.
- Unauthenticated registration allowed seeding malformed IPv6 strings, poisoning the database.

Fix:

- Rewrite `Ipv6IntToIpv6String` to use safe byte padding and `net.IP.String()` instead of brittle hex string manipulation.
- Add `net.ParseIP` validation for BSF `ipv6PrefixRanges.start` and `end` in `nnrfNFManagementOption`.
- Reject registrations containing invalid IPv6 prefix ranges with a 400 Bad Request error.