### PR TITLE
sbi/processor: reject NF registration missing mandatory IEs

### DIFF
--- a/internal/sbi/processor/nf_management.go
+++ b/internal/sbi/processor/nf_management.go
@@ -393,6 +393,18 @@ func (p *Processor) NFRegisterProcedure(
 	nfProfile *models.NrfNfManagementNfProfile,
 ) {
 	logger.NfmLog.Traceln("[NRF] In NFRegisterProcedure")
+
+	if nfProfile.NfInstanceId == "" || nfProfile.NfType == "" || nfProfile.NfStatus == "" {
+		problemDetails := &models.ProblemDetails{
+			Title:  "Mandatory IE missing",
+			Status: http.StatusBadRequest,
+			Detail: "nfInstanceId, nfType and nfStatus are required",
+			Cause:  "MANDATORY_IE_MISSING",
+		}
+		util.GinProblemJson(c, problemDetails)
+		return
+	}
+
 	var nf models.NrfNfManagementNfProfile
 
 	err := nrf_context.NnrfNFManagementDataModel(&nf, nfProfile)


### PR DESCRIPTION
## Summary

`NFRegisterProcedure` persisted NF profiles to MongoDB without validating the three mandatory IEs defined by 3GPP TS 29.510 §5.2.2.2 (`nfInstanceId`, `nfType`, `nfStatus`). A PUT registration that omits any of them was accepted, and the resulting document was stored without those fields.

The consequence for missing `nfStatus` is especially nasty: every subsequent standard PATCH heartbeat from the NF (`{"op":"replace","path":"/nfStatus","value":"REGISTERED"}`) fails in `UpdateNFInstanceProcedure` with:

```
RestfulAPIJSONPatch Apply err: missing value
replace operation does not apply: doc is missing key: /nfStatus
```

NRF then returns HTTP 500 for that NF instance on every heartbeat until the NF re-registers or NRF is restarted, which breaks service discovery for any NF that depends on it.

## Fix

Validate `NfInstanceId`, `NfType` and `NfStatus` up front in `NFRegisterProcedure` and reject with `ProblemDetails{Status: 400, Cause: "MANDATORY_IE_MISSING"}` before the profile ever touches MongoDB. Matches the spec requirement and preserves the heartbeat contract with the rest of the SBA.

Fixes #1024.

## Test

- `go build ./...` green.
- `go vet ./...` clean.
- `go test ./...` passes (only `internal/util` has tests; they pass).

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
