### PR TITLE
fix: NRF oauth2/token panic on poisoned nfInstanceId

### DIFF
--- a/internal/sbi/api_nfmanagement.go
+++ b/internal/sbi/api_nfmanagement.go
@@ -162,6 +162,27 @@ func (s *Server) HTTPRegisterNFInstance(c *gin.Context) {
 		return
 	}
 
+	nfInstanceID := c.Params.ByName("nfInstanceID")
+	if nfInstanceID == "" {
+		problemDetail := &models.ProblemDetails{
+			Title:  "nfInstanceID Empty",
+			Status: http.StatusBadRequest,
+			Detail: "nfInstanceID not exist in request",
+		}
+		util.GinProblemJson(c, problemDetail)
+		return
+	}
+
+	if nfprofile.NfInstanceId != nfInstanceID {
+		problemDetail := &models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "nfInstanceId in body must match nfInstanceID in URI",
+		}
+		util.GinProblemJson(c, problemDetail)
+		return
+	}
+
 	s.Processor().HandleNFRegisterRequest(c, &nfprofile)
 }
 

--- a/internal/sbi/processor/access_token.go
+++ b/internal/sbi/processor/access_token.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
 
 	nrf_context "github.com/free5gc/nrf/internal/context"
@@ -114,6 +115,13 @@ func (p *Processor) AccessTokenScopeCheck(req models.NrfAccessTokenAccessTokenRe
 		}
 	}
 
+	if _, err := uuid.Parse(reqNfInstanceId); err != nil {
+		logger.AccTokenLog.Errorf("invalid nfInstanceId format: %v", err)
+		return &models.AccessTokenErr{
+			Error: "invalid_client",
+		}
+	}
+
 	logger.AccTokenLog.Debugf("reqNfInstanceId: %s", reqNfInstanceId)
 	filter := bson.M{"nfInstanceId": reqNfInstanceId}
 	consumerNfInfo, err := mongoapi.RestfulAPIGetOne(collName, filter)
@@ -172,8 +180,22 @@ func (p *Processor) AccessTokenScopeCheck(req models.NrfAccessTokenAccessTokenRe
 		}
 	}
 
+	if len(nfCert.URIs) == 0 || nfCert.URIs[0] == nil {
+		logger.AccTokenLog.Errorln("Certificate verify error: missing URI SAN")
+		return &models.AccessTokenErr{
+			Error: "invalid_client",
+		}
+	}
+
 	uri := nfCert.URIs[0]
-	id := strings.Split(uri.Opaque, ":")[1]
+	opaqueParts := strings.SplitN(uri.Opaque, ":", 2)
+	if len(opaqueParts) != 2 || opaqueParts[1] == "" {
+		logger.AccTokenLog.Errorf("Certificate verify error: invalid URI SAN format: %s", uri.String())
+		return &models.AccessTokenErr{
+			Error: "invalid_client",
+		}
+	}
+	id := opaqueParts[1]
 	if id != reqNfInstanceId {
 		logger.AccTokenLog.Errorln("Certificate verify error: NF Instance Id mismatch (Expected ID: " +
 			reqNfInstanceId + " Received ID: " + id + ")")

--- a/internal/sbi/processor/nf_management.go
+++ b/internal/sbi/processor/nf_management.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -49,7 +50,11 @@ func (p *Processor) HandleNFRegisterRequest(c *gin.Context, nfProfile *models.Nr
 func (p *Processor) HandleUpdateNFInstanceRequest(c *gin.Context, patchJSON []byte, nfInstanceID string) {
 	logger.NfmLog.Infoln("Handle UpdateNFInstanceRequest")
 
-	response := p.UpdateNFInstanceProcedure(nfInstanceID, patchJSON)
+	response, problemDetails := p.UpdateNFInstanceProcedure(nfInstanceID, patchJSON)
+	if problemDetails != nil {
+		util.GinProblemJson(c, problemDetails)
+		return
+	}
 	if response == nil {
 		c.Status(http.StatusNoContent)
 		return
@@ -327,19 +332,40 @@ func (p *Processor) NFDeregisterProcedure(nfInstanceID string) *models.ProblemDe
 	return nil
 }
 
-func (p *Processor) UpdateNFInstanceProcedure(nfInstanceID string, patchJSON []byte) map[string]interface{} {
+func (p *Processor) UpdateNFInstanceProcedure(
+	nfInstanceID string,
+	patchJSON []byte,
+) (map[string]interface{}, *models.ProblemDetails) {
+	if err := validateNfProfilePatch(patchJSON); err != nil {
+		logger.NfmLog.Warnf("Reject invalid NF profile patch: %v", err)
+		return nil, &models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: err.Error(),
+		}
+	}
+
 	collName := nrf_context.NfProfileCollName
 	filter := bson.M{"nfInstanceId": nfInstanceID}
 
 	if err := mongoapi.RestfulAPIJSONPatch(collName, filter, patchJSON); err != nil {
 		logger.NfmLog.Errorf("UpdateNFInstanceProcedure err: %+v", err)
-		return nil
+		return nil, &models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: err.Error(),
+		}
 	}
 
 	nf, err := mongoapi.RestfulAPIGetOne(collName, filter)
 	if err != nil {
 		logger.NfmLog.Errorf("UpdateNFInstanceProcedure err: %+v", err)
-		return nil
+		return nil, &models.ProblemDetails{
+			Title:  "System failure",
+			Status: http.StatusInternalServerError,
+			Detail: err.Error(),
+			Cause:  "SYSTEM_FAILURE",
+		}
 	}
 
 	nfProfilesRaw := []map[string]interface{}{
@@ -349,11 +375,21 @@ func (p *Processor) UpdateNFInstanceProcedure(nfInstanceID string, patchJSON []b
 	var nfProfiles []models.NrfNfManagementNfProfile
 	if err = timedecode.Decode(nfProfilesRaw, &nfProfiles); err != nil {
 		logger.NfmLog.Errorf("UpdateNFInstanceProcedure err: %+v", err)
+		return nil, &models.ProblemDetails{
+			Title:  "System failure",
+			Status: http.StatusInternalServerError,
+			Detail: err.Error(),
+			Cause:  "SYSTEM_FAILURE",
+		}
 	}
 
 	if len(nfProfiles) == 0 {
 		logger.NfmLog.Warnf("NFProfile[%s] not found", nfInstanceID)
-		return nil
+		return nil, &models.ProblemDetails{
+			Status: http.StatusNotFound,
+			Cause:  "RESOURCE_URI_STRUCTURE_NOT_FOUND",
+			Detail: fmt.Sprintf("NFProfile[%s] not found", nfInstanceID),
+		}
 	}
 
 	uriList := nrf_context.GetNofificationUri(&nfProfiles[0])
@@ -365,7 +401,38 @@ func (p *Processor) UpdateNFInstanceProcedure(nfInstanceID string, patchJSON []b
 	for _, uri := range uriList {
 		p.Consumer().SendNFStatusNotify(context.Background(), Notification_event, nfInstanceUri, uri, &nfProfiles[0])
 	}
-	return nf
+	return nf, nil
+}
+
+func validateNfProfilePatch(patchJSON []byte) error {
+	var operations []map[string]interface{}
+	if err := json.Unmarshal(patchJSON, &operations); err != nil {
+		return fmt.Errorf("invalid JSON Patch payload")
+	}
+
+	for _, operation := range operations {
+		path, ok := operation["path"].(string)
+		if !ok {
+			continue
+		}
+
+		normalizedPath := strings.ToLower(strings.TrimSpace(path))
+		if normalizedPath == "/nfinstanceid" || strings.HasPrefix(normalizedPath, "/nfinstanceid/") {
+			return fmt.Errorf("nfInstanceId is immutable and cannot be modified")
+		}
+
+		from, ok := operation["from"].(string)
+		if !ok {
+			continue
+		}
+
+		normalizedFrom := strings.ToLower(strings.TrimSpace(from))
+		if normalizedFrom == "/nfinstanceid" || strings.HasPrefix(normalizedFrom, "/nfinstanceid/") {
+			return fmt.Errorf("nfInstanceId is immutable and cannot be modified")
+		}
+	}
+
+	return nil
 }
 
 func (p *Processor) GetNFInstanceProcedure(c *gin.Context, nfInstanceID string) {


### PR DESCRIPTION
Fix NRF oauth2/token panic after poisoned nfInstanceId traversal: free5gc/free5gc#947

Files: 
- `internal/sbi/processor/access_token.go`
- `internal/sbi/processor/nf_management.go`
- `internal/sbi/api_nfmanagement.go`

Problem:
- A stateful attack could poison a stored NF profile by patching nfInstanceId to a traversal-like value and then trigger oauth2/token processing with that value.
- Token validation used attacker-controlled nfInstanceId in certificate path selection, which could resolve to base NRF certificate files.
- Access token scope check assumed URI SAN was present and indexed the first element directly, causing panic with index out of range when URI SAN was missing.

Fix:
- Enforced nfInstanceId consistency on NF registration by requiring URI nfInstanceID and body nfInstanceId to match.
- Added JSON Patch validation for NF profile updates and rejected any operation that modifies or moves from nfInstanceId, keeping NF identity immutable.
- Hardened access token validation by rejecting malformed nfInstanceId values that are not UUIDs before lookup/cert handling.
- Replaced unsafe URI SAN indexing with explicit presence and format checks, returning invalid_client on invalid certificate identity data instead of panicking.
- Returned structured ProblemDetails for malformed patch requests and preserved normal behavior for valid NF profile updates.