### PR TITLE
fix: treat nf-type and limit as optional in NFListRetrieve

### DIFF
--- a/internal/sbi/api_nfmanagement.go
+++ b/internal/sbi/api_nfmanagement.go
@@ -10,7 +10,6 @@
 package sbi
 
 import (
-	"fmt"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -220,34 +219,31 @@ func (s *Server) HTTPGetNFInstances(c *gin.Context) {
 	nfType := c.Query("nf-type")
 	limitParam := c.Query("limit")
 
-	if nfType == "" || limitParam == "" {
-		problemDetail := &models.ProblemDetails{
-			Title:  "nfType or limitParam empty",
-			Status: http.StatusBadRequest,
-			Detail: fmt.Sprintf("nfType: %v, limitParam: %v", nfType, limitParam),
+	// Both nf-type and limit are optional per TS 29.510 (required: false).
+	// Only validate limit when it is actually provided.
+	var limit int
+	if limitParam != "" {
+		var err error
+		limit, err = strconv.Atoi(limitParam)
+		if err != nil {
+			logger.NfmLog.Errorln("Error in string conversion: ", limit)
+			problemDetails := &models.ProblemDetails{
+				Title:  "Invalid Parameter",
+				Status: http.StatusBadRequest,
+				Detail: err.Error(),
+			}
+			util.GinProblemJson(c, problemDetails)
+			return
 		}
-		util.GinProblemJson(c, problemDetail)
-		return
-	}
-	limit, err := strconv.Atoi(limitParam)
-	if err != nil {
-		logger.NfmLog.Errorln("Error in string conversion: ", limit)
-		problemDetails := &models.ProblemDetails{
-			Title:  "Invalid Parameter",
-			Status: http.StatusBadRequest,
-			Detail: err.Error(),
+		if limit < 1 {
+			problemDetails := &models.ProblemDetails{
+				Title:  "Invalid Parameter",
+				Status: http.StatusBadRequest,
+				Detail: "limit must be greater than 0",
+			}
+			util.GinProblemJson(c, problemDetails)
+			return
 		}
-		util.GinProblemJson(c, problemDetails)
-		return
-	}
-	if limit < 1 {
-		problemDetails := &models.ProblemDetails{
-			Title:  "Invalid Parameter",
-			Status: http.StatusBadRequest,
-			Detail: "limit must be greater than 0",
-		}
-		util.GinProblemJson(c, problemDetails)
-		return
 	}
 
 	s.Processor().HandleGetNFInstancesRequest(c, nfType, limit)


### PR DESCRIPTION
Fix nf-type and limit requirements for NFListRetrieve service: https://github.com/free5gc/free5gc/issues/1055

Files:

- `internal/sbi/api_nfmanagement.go`

Problem: 

- `HTTPGetNFInstances` returned `400` if either `nf-type` or `limit` was absent, making both effectively required despite being `required: false` in 3GPP TS 29.510.

Fix:

- Removed the mandatory check. `limit` is now only parsed when provided; omitting either parameter is handled gracefully by the existing processor logic.