### PR TITLE
fix: add concrete validation for nfProfile create and patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.2
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
+	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/free5gc/openapi v1.2.4
 	github.com/free5gc/util v1.3.2
 	github.com/gin-gonic/gin v1.10.0
@@ -16,6 +17,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.7
 	go.mongodb.org/mongo-driver v1.17.1
+	golang.org/x/oauth2 v0.27.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -28,7 +30,6 @@ require (
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/free5gc/aper v1.1.1 // indirect
 	github.com/free5gc/nas v1.2.3 // indirect
@@ -75,7 +76,6 @@ require (
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
-	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/internal/sbi/api_nfmanagement.go
+++ b/internal/sbi/api_nfmanagement.go
@@ -182,7 +182,7 @@ func (s *Server) HTTPRegisterNFInstance(c *gin.Context) {
 		return
 	}
 
-	s.Processor().HandleNFRegisterRequest(c, &nfprofile)
+	s.Processor().HandleNFRegisterRequest(c, &nfprofile, requestBody)
 }
 
 // UpdateNFInstance - Update NF Instance profile

--- a/internal/sbi/processor/nf_management.go
+++ b/internal/sbi/processor/nf_management.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
-
 	"github.com/gin-gonic/gin"
 	"github.com/mitchellh/mapstructure"
 	"go.mongodb.org/mongo-driver/bson"
@@ -61,7 +60,11 @@ func (p *Processor) HandleGetNFInstanceRequest(c *gin.Context, nfInstanceId stri
 	p.GetNFInstanceProcedure(c, nfInstanceId)
 }
 
-func (p *Processor) HandleNFRegisterRequest(c *gin.Context, nfProfile *models.NrfNfManagementNfProfile, rawProfile []byte) {
+func (p *Processor) HandleNFRegisterRequest(
+	c *gin.Context,
+	nfProfile *models.NrfNfManagementNfProfile,
+	rawProfile []byte,
+) {
 	logger.NfmLog.Infoln("Handle NFRegisterRequest")
 
 	p.NFRegisterProcedure(c, nfProfile, rawProfile)
@@ -392,7 +395,7 @@ func (p *Processor) UpdateNFInstanceProcedure(
 		}
 	}
 
-	//
+	// apply the JSON Patch to the original NF profile
 	currentJSON, err := json.Marshal(nf)
 	if err != nil {
 		logger.NfmLog.Errorf("UpdateNFInstanceProcedure err: %+v", err)
@@ -419,6 +422,8 @@ func (p *Processor) UpdateNFInstanceProcedure(
 			Detail: err.Error(),
 		}
 	}
+
+	// validate the patched NF profile
 	var patchedProfile models.NrfNfManagementNfProfile
 	if err = json.Unmarshal(patchedJSON, &patchedProfile); err != nil {
 		return nil, &models.ProblemDetails{

--- a/internal/sbi/processor/nf_management.go
+++ b/internal/sbi/processor/nf_management.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	jsonpatch "github.com/evanphx/json-patch/v5"
+
 	"github.com/gin-gonic/gin"
 	"github.com/mitchellh/mapstructure"
 	"go.mongodb.org/mongo-driver/bson"
@@ -59,10 +61,10 @@ func (p *Processor) HandleGetNFInstanceRequest(c *gin.Context, nfInstanceId stri
 	p.GetNFInstanceProcedure(c, nfInstanceId)
 }
 
-func (p *Processor) HandleNFRegisterRequest(c *gin.Context, nfProfile *models.NrfNfManagementNfProfile) {
+func (p *Processor) HandleNFRegisterRequest(c *gin.Context, nfProfile *models.NrfNfManagementNfProfile, rawProfile []byte) {
 	logger.NfmLog.Infoln("Handle NFRegisterRequest")
 
-	p.NFRegisterProcedure(c, nfProfile)
+	p.NFRegisterProcedure(c, nfProfile, rawProfile)
 }
 
 func (p *Processor) HandleUpdateNFInstanceRequest(c *gin.Context, patchJSON []byte, nfInstanceID string) {
@@ -370,6 +372,70 @@ func (p *Processor) UpdateNFInstanceProcedure(
 	collName := nrf_context.NfProfileCollName
 	filter := bson.M{"nfInstanceId": nfInstanceID}
 
+	// read the original NF profile from MongoDB
+	nf, err := mongoapi.RestfulAPIGetOne(collName, filter)
+	if err != nil {
+		logger.NfmLog.Errorf("UpdateNFInstanceProcedure err: %+v", err)
+		return nil, &models.ProblemDetails{
+			Title:  "System failure",
+			Status: http.StatusInternalServerError,
+			Detail: err.Error(),
+			Cause:  "SYSTEM_FAILURE",
+		}
+	}
+	if nf == nil {
+		logger.NfmLog.Warnf("NFProfile[%s] not found", nfInstanceID)
+		return nil, &models.ProblemDetails{
+			Status: http.StatusNotFound,
+			Cause:  "RESOURCE_URI_STRUCTURE_NOT_FOUND",
+			Detail: fmt.Sprintf("NFProfile[%s] not found", nfInstanceID),
+		}
+	}
+
+	//
+	currentJSON, err := json.Marshal(nf)
+	if err != nil {
+		logger.NfmLog.Errorf("UpdateNFInstanceProcedure err: %+v", err)
+		return nil, &models.ProblemDetails{
+			Title:  "System failure",
+			Status: http.StatusInternalServerError,
+			Detail: err.Error(),
+			Cause:  "SYSTEM_FAILURE",
+		}
+	}
+	patch, err := jsonpatch.DecodePatch(patchJSON)
+	if err != nil {
+		return nil, &models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: err.Error(),
+		}
+	}
+	patchedJSON, err := patch.Apply(currentJSON)
+	if err != nil {
+		return nil, &models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: err.Error(),
+		}
+	}
+	var patchedProfile models.NrfNfManagementNfProfile
+	if err = json.Unmarshal(patchedJSON, &patchedProfile); err != nil {
+		return nil, &models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: err.Error(),
+		}
+	}
+	if err := validateNfProfileJSON(patchedJSON, &patchedProfile); err != nil {
+		logger.NfmLog.Warnf("Reject invalid NF profile patch result: %v", err)
+		return nil, &models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: err.Error(),
+		}
+	}
+
 	if err := mongoapi.RestfulAPIJSONPatch(collName, filter, patchJSON); err != nil {
 		logger.NfmLog.Errorf("UpdateNFInstanceProcedure err: %+v", err)
 		return nil, &models.ProblemDetails{
@@ -379,7 +445,7 @@ func (p *Processor) UpdateNFInstanceProcedure(
 		}
 	}
 
-	nf, err := mongoapi.RestfulAPIGetOne(collName, filter)
+	nf, err = mongoapi.RestfulAPIGetOne(collName, filter)
 	if err != nil {
 		logger.NfmLog.Errorf("UpdateNFInstanceProcedure err: %+v", err)
 		return nil, &models.ProblemDetails{
@@ -485,8 +551,19 @@ func (p *Processor) GetNFInstanceProcedure(c *gin.Context, nfInstanceID string) 
 func (p *Processor) NFRegisterProcedure(
 	c *gin.Context,
 	nfProfile *models.NrfNfManagementNfProfile,
+	rawProfile []byte,
 ) {
 	logger.NfmLog.Traceln("[NRF] In NFRegisterProcedure")
+
+	if err := validateNfProfileJSON(rawProfile, nfProfile); err != nil {
+		problemDetails := &models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: err.Error(),
+		}
+		util.GinProblemJson(c, problemDetails)
+		return
+	}
 
 	if nfProfile.NfInstanceId == "" || nfProfile.NfType == "" || nfProfile.NfStatus == "" {
 		problemDetails := &models.ProblemDetails{
@@ -503,6 +580,16 @@ func (p *Processor) NFRegisterProcedure(
 
 	err := nrf_context.NnrfNFManagementDataModel(&nf, nfProfile)
 	if err != nil {
+		problemDetails := &models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: err.Error(),
+		}
+		util.GinProblemJson(c, problemDetails)
+		return
+	}
+
+	if err := validateNfProfile(&nf); err != nil {
 		problemDetails := &models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,

--- a/internal/sbi/processor/nf_profile_validation.go
+++ b/internal/sbi/processor/nf_profile_validation.go
@@ -1,0 +1,228 @@
+package processor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/google/uuid"
+
+	"github.com/free5gc/openapi/models"
+)
+
+const (
+	minHeartBeatTimer = 1
+	maxHeartBeatTimer = 3600
+	maxTCPPort        = 65535
+)
+
+func validateNfProfileJSON(raw []byte, nfProfile *models.NrfNfManagementNfProfile) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return fmt.Errorf("invalid NF profile JSON: %w", err)
+	}
+	if fields == nil {
+		return fmt.Errorf("NF profile must be a JSON object")
+	}
+
+	if rawHeartBeatTimer, ok := fields["heartBeatTimer"]; ok {
+		var heartBeatTimer int32
+		if err := json.Unmarshal(rawHeartBeatTimer, &heartBeatTimer); err != nil {
+			return fmt.Errorf("heartBeatTimer must be an integer")
+		}
+		if !validHeartBeatTimer(heartBeatTimer) {
+			return fmt.Errorf("heartBeatTimer must be between %d and %d", minHeartBeatTimer, maxHeartBeatTimer)
+		}
+	}
+
+	return validateNfProfile(nfProfile)
+}
+
+func validateNfProfile(nfProfile *models.NrfNfManagementNfProfile) error {
+	if nfProfile == nil {
+		return fmt.Errorf("NF profile is required")
+	}
+	if err := validateNfInstanceID(nfProfile.NfInstanceId); err != nil {
+		return err
+	}
+	if !validNfType(nfProfile.NfType) {
+		return fmt.Errorf("invalid nfType: %s", nfProfile.NfType)
+	}
+	if !validNfStatus(nfProfile.NfStatus) {
+		return fmt.Errorf("invalid nfStatus: %s", nfProfile.NfStatus)
+	}
+	if nfProfile.HeartBeatTimer != 0 && !validHeartBeatTimer(nfProfile.HeartBeatTimer) {
+		return fmt.Errorf("heartBeatTimer must be between %d and %d", minHeartBeatTimer, maxHeartBeatTimer)
+	}
+
+	for index, address := range nfProfile.Ipv4Addresses {
+		if !validIPv4(address) {
+			return fmt.Errorf("invalid ipv4Addresses[%d]: %s", index, address)
+		}
+	}
+	for index, address := range nfProfile.Ipv6Addresses {
+		if !validIPv6(address) {
+			return fmt.Errorf("invalid ipv6Addresses[%d]: %s", index, address)
+		}
+	}
+
+	for serviceIndex, service := range nfProfile.NfServices {
+		if service.Scheme != "" && !validURIScheme(service.Scheme) {
+			return fmt.Errorf("invalid nfServices[%d].scheme: %s", serviceIndex, service.Scheme)
+		}
+		if service.NfServiceStatus != "" && !validNfServiceStatus(service.NfServiceStatus) {
+			return fmt.Errorf("invalid nfServices[%d].nfServiceStatus: %s", serviceIndex, service.NfServiceStatus)
+		}
+		for endpointIndex, endpoint := range service.IpEndPoints {
+			if err := validateIPEndPoint(endpoint); err != nil {
+				return fmt.Errorf("invalid nfServices[%d].ipEndPoints[%d]: %w", serviceIndex, endpointIndex, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateNfInstanceID(nfInstanceID string) error {
+	parsed, err := uuid.Parse(nfInstanceID)
+	if err != nil {
+		return fmt.Errorf("nfInstanceId must be a UUID v4")
+	}
+	if parsed.Version() != 4 {
+		return fmt.Errorf("nfInstanceId must be a UUID v4")
+	}
+	return nil
+}
+
+func validateIPEndPoint(endpoint models.IpEndPoint) error {
+	if endpoint.Transport != "" && endpoint.Transport != models.NrfNfManagementTransportProtocol_TCP {
+		return fmt.Errorf("transport must be TCP")
+	}
+	if endpoint.Port != 0 && (endpoint.Port < 1 || endpoint.Port > maxTCPPort) {
+		return fmt.Errorf("port must be between 1 and %d", maxTCPPort)
+	}
+
+	if endpoint.Ipv4Address != "" {
+		ip := net.ParseIP(endpoint.Ipv4Address)
+		if ip == nil || ip.To4() == nil {
+			return fmt.Errorf("invalid ipv4Address: %s", endpoint.Ipv4Address)
+		}
+	}
+	if endpoint.Ipv6Address != "" {
+		ip := net.ParseIP(endpoint.Ipv6Address)
+		if ip == nil || ip.To4() != nil {
+			return fmt.Errorf("invalid ipv6Address: %s", endpoint.Ipv6Address)
+		}
+	}
+
+	return nil
+}
+
+func validHeartBeatTimer(heartBeatTimer int32) bool {
+	return heartBeatTimer >= minHeartBeatTimer && heartBeatTimer <= maxHeartBeatTimer
+}
+
+func validIPv4(address string) bool {
+	ip := net.ParseIP(address)
+	return ip != nil && ip.To4() != nil
+}
+
+func validIPv6(address string) bool {
+	ip := net.ParseIP(address)
+	return ip != nil && ip.To4() == nil
+}
+
+func validNfStatus(status models.NrfNfManagementNfStatus) bool {
+	switch status {
+	case models.NrfNfManagementNfStatus_REGISTERED,
+		models.NrfNfManagementNfStatus_SUSPENDED,
+		models.NrfNfManagementNfStatus_UNDISCOVERABLE:
+		return true
+	default:
+		return false
+	}
+}
+
+func validNfServiceStatus(status models.NfServiceStatus) bool {
+	switch status {
+	case models.NfServiceStatus_REGISTERED,
+		models.NfServiceStatus_SUSPENDED,
+		models.NfServiceStatus_UNDISCOVERABLE:
+		return true
+	default:
+		return false
+	}
+}
+
+func validURIScheme(scheme models.UriScheme) bool {
+	switch scheme {
+	case models.UriScheme_HTTP, models.UriScheme_HTTPS:
+		return true
+	default:
+		return false
+	}
+}
+
+func validNfType(nfType models.NrfNfManagementNfType) bool {
+	switch nfType {
+	case models.NrfNfManagementNfType_NRF,
+		models.NrfNfManagementNfType_UDM,
+		models.NrfNfManagementNfType_AMF,
+		models.NrfNfManagementNfType_SMF,
+		models.NrfNfManagementNfType_AUSF,
+		models.NrfNfManagementNfType_NEF,
+		models.NrfNfManagementNfType_PCF,
+		models.NrfNfManagementNfType_SMSF,
+		models.NrfNfManagementNfType_NSSF,
+		models.NrfNfManagementNfType_UDR,
+		models.NrfNfManagementNfType_LMF,
+		models.NrfNfManagementNfType_GMLC,
+		models.NrfNfManagementNfType__5_G_EIR,
+		models.NrfNfManagementNfType_SEPP,
+		models.NrfNfManagementNfType_UPF,
+		models.NrfNfManagementNfType_N3_IWF,
+		models.NrfNfManagementNfType_AF,
+		models.NrfNfManagementNfType_UDSF,
+		models.NrfNfManagementNfType_BSF,
+		models.NrfNfManagementNfType_CHF,
+		models.NrfNfManagementNfType_NWDAF,
+		models.NrfNfManagementNfType_PCSCF,
+		models.NrfNfManagementNfType_CBCF,
+		models.NrfNfManagementNfType_HSS,
+		models.NrfNfManagementNfType_UCMF,
+		models.NrfNfManagementNfType_SOR_AF,
+		models.NrfNfManagementNfType_SPAF,
+		models.NrfNfManagementNfType_MME,
+		models.NrfNfManagementNfType_SCSAS,
+		models.NrfNfManagementNfType_SCEF,
+		models.NrfNfManagementNfType_SCP,
+		models.NrfNfManagementNfType_NSSAAF,
+		models.NrfNfManagementNfType_ICSCF,
+		models.NrfNfManagementNfType_SCSCF,
+		models.NrfNfManagementNfType_DRA,
+		models.NrfNfManagementNfType_IMS_AS,
+		models.NrfNfManagementNfType_AANF,
+		models.NrfNfManagementNfType__5_G_DDNMF,
+		models.NrfNfManagementNfType_NSACF,
+		models.NrfNfManagementNfType_MFAF,
+		models.NrfNfManagementNfType_EASDF,
+		models.NrfNfManagementNfType_DCCF,
+		models.NrfNfManagementNfType_MB_SMF,
+		models.NrfNfManagementNfType_TSCTSF,
+		models.NrfNfManagementNfType_ADRF,
+		models.NrfNfManagementNfType_GBA_BSF,
+		models.NrfNfManagementNfType_CEF,
+		models.NrfNfManagementNfType_MB_UPF,
+		models.NrfNfManagementNfType_NSWOF,
+		models.NrfNfManagementNfType_PKMF,
+		models.NrfNfManagementNfType_MNPF,
+		models.NrfNfManagementNfType_SMS_GMSC,
+		models.NrfNfManagementNfType_SMS_IWMSC,
+		models.NrfNfManagementNfType_MBSF,
+		models.NrfNfManagementNfType_MBSTF,
+		models.NrfNfManagementNfType_PANF:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/sbi/processor/nf_profile_validation_test.go
+++ b/internal/sbi/processor/nf_profile_validation_test.go
@@ -1,0 +1,114 @@
+package processor
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/free5gc/openapi/models"
+)
+
+func validTestNfProfile() models.NrfNfManagementNfProfile {
+	return models.NrfNfManagementNfProfile{
+		NfInstanceId: "11111111-1111-4111-8111-111111111111",
+		NfType:       models.NrfNfManagementNfType_AMF,
+		NfStatus:     models.NrfNfManagementNfStatus_REGISTERED,
+		NfServices: []models.NrfNfManagementNfService{
+			{
+				ServiceInstanceId: "namf-comm",
+				ServiceName:       models.ServiceName_NAMF_COMM,
+				Scheme:            models.UriScheme_HTTP,
+				NfServiceStatus:   models.NfServiceStatus_REGISTERED,
+				IpEndPoints: []models.IpEndPoint{
+					{
+						Ipv4Address: "127.0.0.18",
+						Transport:   models.NrfNfManagementTransportProtocol_TCP,
+						Port:        8000,
+					},
+				},
+			},
+		},
+	}
+}
+
+func validateTestProfile(t *testing.T, profile models.NrfNfManagementNfProfile) error {
+	t.Helper()
+	raw, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatalf("marshal profile: %v", err)
+	}
+	return validateNfProfileJSON(raw, &profile)
+}
+
+func TestValidateNfProfileAcceptsValidProfile(t *testing.T) {
+	if err := validateTestProfile(t, validTestNfProfile()); err != nil {
+		t.Fatalf("expected valid profile, got error: %v", err)
+	}
+}
+
+func TestValidateNfProfileRejectsNonUUIDInstanceID(t *testing.T) {
+	profile := validTestNfProfile()
+	profile.NfInstanceId = "not-a-uuid"
+
+	if err := validateTestProfile(t, profile); err == nil {
+		t.Fatal("expected non-UUID nfInstanceId to be rejected")
+	}
+}
+
+func TestValidateNfProfileRejectsNonV4UUIDInstanceID(t *testing.T) {
+	profile := validTestNfProfile()
+	profile.NfInstanceId = "11111111-1111-1111-8111-111111111111"
+
+	if err := validateTestProfile(t, profile); err == nil {
+		t.Fatal("expected non-v4 nfInstanceId to be rejected")
+	}
+}
+
+func TestValidateNfProfileRejectsInvalidNFStatus(t *testing.T) {
+	profile := validTestNfProfile()
+	profile.NfStatus = models.NrfNfManagementNfStatus("INVALID_STATUS")
+
+	if err := validateTestProfile(t, profile); err == nil {
+		t.Fatal("expected invalid nfStatus to be rejected")
+	}
+}
+
+func TestValidateNfProfileRejectsInvalidNFType(t *testing.T) {
+	profile := validTestNfProfile()
+	profile.NfType = models.NrfNfManagementNfType("INVALID_TYPE")
+
+	if err := validateTestProfile(t, profile); err == nil {
+		t.Fatal("expected invalid nfType to be rejected")
+	}
+}
+
+func TestValidateNfProfileRejectsExplicitZeroHeartbeat(t *testing.T) {
+	profile := validTestNfProfile()
+	raw := []byte(`{
+		"nfInstanceId":"11111111-1111-4111-8111-111111111111",
+		"nfType":"AMF",
+		"nfStatus":"REGISTERED",
+		"heartBeatTimer":0
+	}`)
+
+	if err := validateNfProfileJSON(raw, &profile); err == nil {
+		t.Fatal("expected explicit zero heartBeatTimer to be rejected")
+	}
+}
+
+func TestValidateNfProfileRejectsInvalidEndpointIP(t *testing.T) {
+	profile := validTestNfProfile()
+	profile.NfServices[0].IpEndPoints[0].Ipv4Address = "999.0.0.1"
+
+	if err := validateTestProfile(t, profile); err == nil {
+		t.Fatal("expected invalid endpoint IPv4 address to be rejected")
+	}
+}
+
+func TestValidateNfProfileRejectsInvalidEndpointPort(t *testing.T) {
+	profile := validTestNfProfile()
+	profile.NfServices[0].IpEndPoints[0].Port = 70000
+
+	if err := validateTestProfile(t, profile); err == nil {
+		t.Fatal("expected invalid endpoint port to be rejected")
+	}
+}


### PR DESCRIPTION
Fix NRF NF profile validation for NF registration poisoning: https://github.com/free5gc/free5gc/issues/1056

Files:

- `internal/sbi/api_nfmanagement.go`
- `internal/sbi/processor/nf_management.go`
- `internal/sbi/processor/nf_profile_validation.go`
- `internal/sbi/processor/nf_profile_validation_test.go`

Problem:

- NRF accepted invalid NF registration data and stored it in MongoDB.
- Invalid profiles could include non-UUID `nfInstanceId`, invalid `nfType` / `nfStatus`, and out-of-range `heartBeatTimer`.
- Invalid or poisoned NF profiles could later appear in NF Discovery results and be used by other NFs.

Fix:

- Added centralized NF profile validation before registration data is stored.
- Validates UUID v4 `nfInstanceId`, NF type/status enums, heartbeat range, IP address format, URI scheme, and service status.
- Preserves raw JSON validation so explicit `heartBeatTimer: 0` can be rejected.
- Validates PATCH results in memory before applying updates to MongoDB.
- Added unit tests for valid profiles and key invalid profile cases.