### PR TITLE
fix: allow hostname alias for NfProfile IPv4 check

### DIFF
--- a/internal/sbi/processor/nf_profile_validation.go
+++ b/internal/sbi/processor/nf_profile_validation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -16,6 +17,7 @@ const (
 	maxTCPPort        = 65535
 )
 
+// validateNfProfileJSON validates raw JSON fields before checking the decoded profile.
 func validateNfProfileJSON(raw []byte, nfProfile *models.NrfNfManagementNfProfile) error {
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &fields); err != nil {
@@ -38,6 +40,7 @@ func validateNfProfileJSON(raw []byte, nfProfile *models.NrfNfManagementNfProfil
 	return validateNfProfile(nfProfile)
 }
 
+// validateNfProfile validates semantic constraints on a decoded NF profile.
 func validateNfProfile(nfProfile *models.NrfNfManagementNfProfile) error {
 	if nfProfile == nil {
 		return fmt.Errorf("NF profile is required")
@@ -56,7 +59,7 @@ func validateNfProfile(nfProfile *models.NrfNfManagementNfProfile) error {
 	}
 
 	for index, address := range nfProfile.Ipv4Addresses {
-		if !validIPv4(address) {
+		if !validIPv4OrHostname(address) {
 			return fmt.Errorf("invalid ipv4Addresses[%d]: %s", index, address)
 		}
 	}
@@ -83,6 +86,7 @@ func validateNfProfile(nfProfile *models.NrfNfManagementNfProfile) error {
 	return nil
 }
 
+// validateNfInstanceID requires an NF instance ID to be UUID v4.
 func validateNfInstanceID(nfInstanceID string) error {
 	parsed, err := uuid.Parse(nfInstanceID)
 	if err != nil {
@@ -94,6 +98,7 @@ func validateNfInstanceID(nfInstanceID string) error {
 	return nil
 }
 
+// validateIPEndPoint validates service endpoint transport, port, and address format.
 func validateIPEndPoint(endpoint models.IpEndPoint) error {
 	if endpoint.Transport != "" && endpoint.Transport != models.NrfNfManagementTransportProtocol_TCP {
 		return fmt.Errorf("transport must be TCP")
@@ -103,8 +108,7 @@ func validateIPEndPoint(endpoint models.IpEndPoint) error {
 	}
 
 	if endpoint.Ipv4Address != "" {
-		ip := net.ParseIP(endpoint.Ipv4Address)
-		if ip == nil || ip.To4() == nil {
+		if !validIPv4OrHostname(endpoint.Ipv4Address) {
 			return fmt.Errorf("invalid ipv4Address: %s", endpoint.Ipv4Address)
 		}
 	}
@@ -118,20 +122,75 @@ func validateIPEndPoint(endpoint models.IpEndPoint) error {
 	return nil
 }
 
+// validHeartBeatTimer checks the allowed heartbeat timer range.
 func validHeartBeatTimer(heartBeatTimer int32) bool {
 	return heartBeatTimer >= minHeartBeatTimer && heartBeatTimer <= maxHeartBeatTimer
 }
 
+// validIPv4OrHostname accepts an IPv4 literal or DNS-style hostname.
+func validIPv4OrHostname(address string) bool {
+	return validIPv4(address) || validHostname(address)
+}
+
+// validIPv4 reports whether address is an IPv4 literal.
 func validIPv4(address string) bool {
 	ip := net.ParseIP(address)
 	return ip != nil && ip.To4() != nil
 }
 
+// validHostname reports whether address is a valid DNS-style hostname.
+func validHostname(address string) bool {
+	if address == "" || len(address) > 253 || isDottedIPv4(address) {
+		return false
+	}
+	address = strings.TrimSuffix(address, ".")
+	labels := strings.Split(address, ".")
+	hasLetter := false
+	for _, label := range labels {
+		if len(label) == 0 || len(label) > 63 || label[0] == 45 || label[len(label)-1] == 45 {
+			return false
+		}
+		for i := 0; i < len(label); i++ {
+			c := label[i]
+			if c >= 97 && c <= 122 || c >= 65 && c <= 90 {
+				hasLetter = true
+				continue
+			}
+			if c >= 48 && c <= 57 || c == 45 {
+				continue
+			}
+			return false
+		}
+	}
+	return hasLetter
+}
+
+// isDottedIPv4 detects dotted numeric values that should not pass as hostnames.
+func isDottedIPv4(address string) bool {
+	parts := strings.Split(address, ".")
+	if len(parts) != 4 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for i := 0; i < len(part); i++ {
+			if part[i] < 48 || part[i] > 57 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// validIPv6 reports whether address is an IPv6 literal.
 func validIPv6(address string) bool {
 	ip := net.ParseIP(address)
 	return ip != nil && ip.To4() == nil
 }
 
+// validNfStatus checks allowed NF status enum values.
 func validNfStatus(status models.NrfNfManagementNfStatus) bool {
 	switch status {
 	case models.NrfNfManagementNfStatus_REGISTERED,
@@ -143,6 +202,7 @@ func validNfStatus(status models.NrfNfManagementNfStatus) bool {
 	}
 }
 
+// validNfServiceStatus checks allowed NF service status enum values.
 func validNfServiceStatus(status models.NfServiceStatus) bool {
 	switch status {
 	case models.NfServiceStatus_REGISTERED,
@@ -154,6 +214,7 @@ func validNfServiceStatus(status models.NfServiceStatus) bool {
 	}
 }
 
+// validURIScheme checks allowed service URI schemes.
 func validURIScheme(scheme models.UriScheme) bool {
 	switch scheme {
 	case models.UriScheme_HTTP, models.UriScheme_HTTPS:
@@ -163,6 +224,7 @@ func validURIScheme(scheme models.UriScheme) bool {
 	}
 }
 
+// validNfType checks allowed NF type enum values.
 func validNfType(nfType models.NrfNfManagementNfType) bool {
 	switch nfType {
 	case models.NrfNfManagementNfType_NRF,

--- a/internal/sbi/processor/nf_profile_validation_test.go
+++ b/internal/sbi/processor/nf_profile_validation_test.go
@@ -95,6 +95,16 @@ func TestValidateNfProfileRejectsExplicitZeroHeartbeat(t *testing.T) {
 	}
 }
 
+func TestValidateNfProfileAcceptsDockerComposeFQDNAlias(t *testing.T) {
+	profile := validTestNfProfile()
+	profile.Ipv4Addresses = []string{"nssf.free5gc.org"}
+	profile.NfServices[0].IpEndPoints[0].Ipv4Address = "nssf.free5gc.org"
+
+	if err := validateTestProfile(t, profile); err != nil {
+		t.Fatalf("expected Docker Compose FQDN alias to be accepted, got error: %v", err)
+	}
+}
+
 func TestValidateNfProfileRejectsInvalidEndpointIP(t *testing.T) {
 	profile := validTestNfProfile()
 	profile.NfServices[0].IpEndPoints[0].Ipv4Address = "999.0.0.1"


### PR DESCRIPTION
Fix NRF NF profile validation for Docker Compose aliases

Problem:
- free5GC Docker Compose configs use DNS-style aliases such as `nssf.free5gc.org` in fields like `registerIPv4`.
- The new NRF profile validation only accepted IPv4 literals, so valid Compose-based NF registrations could be rejected.

Fix:
- Allow `ipv4Addresses` and `nfServices[].ipEndPoints[].ipv4Address` to contain either an IPv4 literal or a DNS-style hostname.
- Continue rejecting malformed IPv4-looking values such as `999.0.0.1`.
- Added a regression test for `nssf.free5gc.org`.