### PR TITLE
feat(nfm): enforce the NF heart-beat procedure

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -31,8 +30,6 @@ type NRFContext struct {
 	NrfPrivKey       *rsa.PrivateKey
 	NrfPubKey        *rsa.PublicKey
 	NrfCert          *x509.Certificate
-	NfRegistNum      int
-	nfRegistNumLock  sync.RWMutex
 }
 
 const (
@@ -56,7 +53,6 @@ func InitNrfContext() error {
 	nrfContext.NrfNfProfile.NfInstanceId = config.GetNfInstanceId()
 	nrfContext.NrfNfProfile.NfType = models.NrfNfManagementNfType_NRF
 	nrfContext.NrfNfProfile.NfStatus = models.NrfNfManagementNfStatus_REGISTERED
-	nrfContext.NfRegistNum = 0
 
 	serviceNameList := configuration.ServiceNameList
 
@@ -259,16 +255,4 @@ func (ctx *NRFContext) GetTokenCtx(
 		Expiry:      time.Unix(int64(now+expiration), 0),
 	})
 	return context.WithValue(context.Background(), openapi.ContextOAuth2, tok), nil, nil
-}
-
-func (ctx *NRFContext) AddNfRegister() {
-	ctx.nfRegistNumLock.Lock()
-	defer ctx.nfRegistNumLock.Unlock()
-	ctx.NfRegistNum += 1
-}
-
-func (ctx *NRFContext) DelNfRegister() {
-	ctx.nfRegistNumLock.Lock()
-	defer ctx.nfRegistNumLock.Unlock()
-	ctx.NfRegistNum -= 1
 }

--- a/internal/context/management_data.go
+++ b/internal/context/management_data.go
@@ -59,10 +59,9 @@ func SetsubscriptionId() (string, error) {
 }
 
 func nnrfNFManagementCondition(nf *models.NrfNfManagementNfProfile, nfprofile *models.NrfNfManagementNfProfile) {
-	// HeartBeatTimer
-	if nfprofile.HeartBeatTimer >= 0 {
-		nf.HeartBeatTimer = nfprofile.HeartBeatTimer
-	}
+	// HeartBeatTimer: the NRF owns the interval (TS 29.510 clause 5.2.2.3). The
+	// NF's proposal is ignored; the response carries the value we enforce.
+	nf.HeartBeatTimer = int32(factory.NrfConfig.GetHeartbeatTimer())
 	// PlmnList
 	if nfprofile.PlmnList != nil {
 		plmnList := make([]models.PlmnId, len(nfprofile.PlmnList))

--- a/internal/sbi/processor/nf_discovery.go
+++ b/internal/sbi/processor/nf_discovery.go
@@ -16,6 +16,7 @@ import (
 	nrf_context "github.com/free5gc/nrf/internal/context"
 	"github.com/free5gc/nrf/internal/logger"
 	"github.com/free5gc/nrf/internal/util"
+	"github.com/free5gc/nrf/pkg/factory"
 	"github.com/free5gc/openapi/models"
 	timedecode "github.com/free5gc/util/mapstruct"
 	"github.com/free5gc/util/mongoapi"
@@ -198,7 +199,9 @@ func (p *Processor) NFDiscoveryProcedure(c *gin.Context, queryParameters url.Val
 			}
 		}
 	}
-	validityPeriod := 100
+	// Cache lifetime tracks the suspension deadline: a longer value would let
+	// consumers keep routing to instances we already suspended.
+	validityPeriod := factory.NrfConfig.GetHeartbeatTimer() * factory.NrfConfig.GetHeartbeatSuspendFactor()
 	// Build SearchResult model
 	searchResult := &models.SearchResult{
 		ValidityPeriod: int32(validityPeriod),
@@ -212,6 +215,10 @@ func buildFilter(queryParameters url.Values) (bson.M, error) {
 	filter := bson.M{
 		"$and": []bson.M{},
 	}
+
+	// Suspended instances are not discoverable (TS 29.510 clause 5.2.2.3).
+	filter["$and"] = append(filter["$and"].([]bson.M),
+		bson.M{"nfStatus": string(models.NrfNfManagementNfStatus_REGISTERED)})
 
 	// [Query-1] target-nf-type
 	targetNfType := queryParameters["target-nf-type"][0]

--- a/internal/sbi/processor/nf_management.go
+++ b/internal/sbi/processor/nf_management.go
@@ -632,6 +632,24 @@ func (p *Processor) UpdateNFInstanceProcedure(
 			Detail: err.Error(),
 		}
 	}
+	var originalProfile models.NrfNfManagementNfProfile
+	if err = json.Unmarshal(currentJSON, &originalProfile); err != nil {
+		logger.NfmLog.Errorf("UpdateNFInstanceProcedure err: %+v", err)
+		return nil, &models.ProblemDetails{
+			Title:  "System failure",
+			Status: http.StatusInternalServerError,
+			Detail: err.Error(),
+			Cause:  "SYSTEM_FAILURE",
+		}
+	}
+	if err := checkPatchInvariants(&originalProfile, &patchedProfile); err != nil {
+		logger.NfmLog.Warnf("Reject invalid NF profile patch result: %v", err)
+		return nil, &models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: err.Error(),
+		}
+	}
 
 	// The NFUpdate is the heart-beat (TS 29.510 clause 5.2.2.3): stamp it
 	// before the patch stores REGISTERED, or a concurrent sweep could claim
@@ -759,6 +777,19 @@ func validateNfProfilePatch(patchJSON []byte) error {
 		}
 	}
 
+	return nil
+}
+
+// checkPatchInvariants rejects a patch whose result changed an NRF-owned
+// field. The path guards in validateNfProfilePatch cannot see a whole-document
+// op (path "", RFC 6901), so the applied result is checked too.
+func checkPatchInvariants(original, patched *models.NrfNfManagementNfProfile) error {
+	if patched.NfInstanceId != original.NfInstanceId {
+		return fmt.Errorf("nfInstanceId is immutable and cannot be modified")
+	}
+	if patched.HeartBeatTimer != original.HeartBeatTimer {
+		return fmt.Errorf("heartBeatTimer is set by the NRF and cannot be modified")
+	}
 	return nil
 }
 

--- a/internal/sbi/processor/nf_management.go
+++ b/internal/sbi/processor/nf_management.go
@@ -213,12 +213,20 @@ func (p *Processor) DropStaleSuspendedNfProfiles(ctx context.Context) {
 // touchLastHeartBeat records the contact the sweeps measure against. Stored
 // as fixed-width UTC RFC3339: $lt needs lexicographic order to match
 // chronological order, which fractional seconds or a zone offset would break.
+//
+// heartBeatTimer is re-stamped too: it is baked in at registration, and the
+// sweeps use the current configuration, so after a config change an NF ticking
+// at the old interval could flap into SUSPENDED. NFs adopt the value from
+// every 200 response, which is read from the document after this write.
 func touchLastHeartBeat(nfInstanceID string) error {
 	_, err := mongoapi.Client.Database(factory.NrfConfig.Configuration.MongoDBName).
 		Collection(nrf_context.NfProfileCollName).
 		UpdateOne(context.Background(),
 			bson.M{"nfInstanceId": nfInstanceID},
-			bson.M{"$set": bson.M{"lastHeartBeat": time.Now().UTC().Format(time.RFC3339)}})
+			bson.M{"$set": bson.M{
+				"lastHeartBeat":  time.Now().UTC().Format(time.RFC3339),
+				"heartBeatTimer": int32(factory.NrfConfig.GetHeartbeatTimer()),
+			}})
 	return err
 }
 

--- a/internal/sbi/processor/nf_management.go
+++ b/internal/sbi/processor/nf_management.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -13,6 +14,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/mitchellh/mapstructure"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 
 	nrf_context "github.com/free5gc/nrf/internal/context"
 	"github.com/free5gc/nrf/internal/logger"
@@ -40,6 +43,197 @@ func (p *Processor) getNFNotifyCtx(targetNF models.NrfNfManagementNfType) (conte
 		return nil, pd
 	}
 	return ctx, nil
+}
+
+// sweepBatchSize bounds one pass of either sweep; a larger backlog drains
+// over the following ticks.
+const sweepBatchSize = 256
+
+// SuspendStaleNfProfiles moves instances silent for timer * suspendFactor
+// seconds to SUSPENDED, out of discovery, and notifies their subscribers
+// (TS 29.510 clause 5.2.2.3).
+//
+// Each instance is claimed with an atomic findOneAndUpdate, so replicas
+// sharing a database notify disjoint sets. The deadline uses our configured
+// timer, never the stored profile's, which an NF could inflate. Instances
+// without a lastHeartBeat wait for their next NFUpdate to stamp one.
+func (p *Processor) SuspendStaleNfProfiles(ctx context.Context) {
+	deadline := time.Duration(factory.NrfConfig.GetHeartbeatTimer()*
+		factory.NrfConfig.GetHeartbeatSuspendFactor()) * time.Second
+	now := time.Now().UTC()
+	cutoff := now.Add(-deadline).Format(time.RFC3339)
+
+	coll := mongoapi.Client.Database(factory.NrfConfig.Configuration.MongoDBName).
+		Collection(nrf_context.NfProfileCollName)
+
+	for i := 0; i < sweepBatchSize; i++ {
+		var raw map[string]interface{}
+		err := coll.FindOneAndUpdate(ctx,
+			bson.M{
+				"nfStatus":      string(models.NrfNfManagementNfStatus_REGISTERED),
+				"lastHeartBeat": bson.M{"$lt": cutoff},
+			},
+			// suspendedAt starts the drop clock. The filter only matches
+			// REGISTERED instances, so the stamp is fresh at every transition.
+			bson.M{"$set": bson.M{
+				"nfStatus":    string(models.NrfNfManagementNfStatus_SUSPENDED),
+				"suspendedAt": now.Format(time.RFC3339),
+			}},
+			options.FindOneAndUpdate().SetReturnDocument(options.After),
+		).Decode(&raw)
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return
+		}
+		if err != nil {
+			logger.NfmLog.Errorf("Suspend stale NF profiles err: %+v", err)
+			return
+		}
+
+		var nfProfiles []models.NrfNfManagementNfProfile
+		if err = timedecode.Decode([]map[string]interface{}{raw}, &nfProfiles); err != nil || len(nfProfiles) == 0 {
+			logger.NfmLog.Errorf("Suspended NF profile decode error: %+v", err)
+			continue
+		}
+		logger.NfmLog.Infof("NF suspended, no heart-beat received: %v [%v]",
+			nfProfiles[0].NfType, nfProfiles[0].NfInstanceId)
+		p.notifySubscribers(models.NotificationEventType_PROFILE_CHANGED, &nfProfiles[0])
+	}
+}
+
+// notifySubscribers notifies every subscriber of the profile; failures are
+// logged so one unreachable target does not starve the rest. DEREGISTERED
+// carries no payload, as in NFDeregisterProcedure.
+func (p *Processor) notifySubscribers(
+	event models.NotificationEventType,
+	nfProfile *models.NrfNfManagementNfProfile,
+) {
+	payload := nfProfile
+	if event == models.NotificationEventType_DEREGISTERED {
+		payload = nil
+	}
+	nfInstanceUri := nrf_context.GetNfInstanceURI(nfProfile.NfInstanceId)
+	for _, target := range nrf_context.GetNofificationUri(nfProfile) {
+		notifCtx, pd := p.getNFNotifyCtx(target.TargetNf)
+		if pd != nil {
+			logger.NfmLog.Errorf("Notify %s failed: %+v", target.Uri, pd)
+			continue
+		}
+		if pd = p.Consumer().SendNFStatusNotify(notifCtx,
+			event, nfInstanceUri, target.Uri, payload); pd != nil {
+			logger.NfmLog.Errorf("Notify %s failed: %+v", target.Uri, pd)
+		}
+	}
+}
+
+// DropStaleSuspendedNfProfiles deregisters instances that stayed SUSPENDED
+// for more than dropDelay seconds (TS 29.510 clause 5.2.2.3), and does
+// nothing when dropDelay is unset. Without it, every NF restarting under a
+// fresh nfInstanceId leaves a stale SUSPENDED document behind forever.
+//
+// Guards against dropping a live instance:
+//   - The delay counts from suspendedAt, so after an NRF outage an instance
+//     still gets a full heart-beat window (the caller's startup grace).
+//   - An instance with a fresh lastHeartBeat is never claimed.
+//   - findOneAndDelete claims atomically: with several replicas, exactly one
+//     deregisters an instance, and its subscribers hear DEREGISTERED once.
+//   - An NF re-registers on a heart-beat 404, so an instance dropped while
+//     still alive is back in the registry on its next heart-beat.
+func (p *Processor) DropStaleSuspendedNfProfiles(ctx context.Context) {
+	// A zero delay would put the cutoff at now and drop every suspended
+	// instance on sight, so the guard stays here rather than in the caller.
+	delay := factory.NrfConfig.GetHeartbeatDropDelay()
+	if delay <= 0 {
+		return
+	}
+	now := time.Now().UTC()
+	cutoff := now.Add(-time.Duration(delay) * time.Second).Format(time.RFC3339)
+
+	coll := mongoapi.Client.Database(factory.NrfConfig.Configuration.MongoDBName).
+		Collection(nrf_context.NfProfileCollName)
+
+	// SUSPENDED documents without suspendedAt (older builds, or an NF that
+	// patched itself SUSPENDED) start their clock now: dropped one full delay
+	// later, never on sight.
+	if _, err := coll.UpdateMany(ctx,
+		bson.M{
+			"nfStatus":    string(models.NrfNfManagementNfStatus_SUSPENDED),
+			"suspendedAt": bson.M{"$exists": false},
+		},
+		bson.M{"$set": bson.M{"suspendedAt": now.Format(time.RFC3339)}}); err != nil {
+		logger.NfmLog.Errorf("Backfill suspendedAt err: %+v", err)
+	}
+
+	for i := 0; i < sweepBatchSize; i++ {
+		var raw map[string]interface{}
+		err := coll.FindOneAndDelete(ctx, bson.M{
+			"nfStatus":    string(models.NrfNfManagementNfStatus_SUSPENDED),
+			"suspendedAt": bson.M{"$lt": cutoff},
+			"$or": []bson.M{
+				{"lastHeartBeat": bson.M{"$lt": cutoff}},
+				{"lastHeartBeat": bson.M{"$exists": false}},
+			},
+		}).Decode(&raw)
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return
+		}
+		if err != nil {
+			logger.NfmLog.Errorf("Drop stale suspended NF profiles err: %+v", err)
+			return
+		}
+
+		var nfProfiles []models.NrfNfManagementNfProfile
+		if err = timedecode.Decode([]map[string]interface{}{raw}, &nfProfiles); err != nil || len(nfProfiles) == 0 {
+			logger.NfmLog.Errorf("Dropped NF profile decode error: %+v", err)
+			continue
+		}
+		profile := &nfProfiles[0]
+		logger.NfmLog.Infof("NF profile dropped, SUSPENDED since %v: %v [%v]",
+			raw["suspendedAt"], profile.NfType, profile.NfInstanceId)
+
+		// Same cleanup as NFDeregisterProcedure, logged rather than propagated:
+		// no client waits on the sweep.
+		p.notifySubscribers(models.NotificationEventType_DEREGISTERED, profile)
+		putData := bson.M{
+			"_link.item": bson.M{"href": nrf_context.GetNfInstanceURI(profile.NfInstanceId)},
+			"multi":      true,
+		}
+		if pullErr := mongoapi.RestfulAPIPullOne("urilist", bson.M{"nfType": profile.NfType}, putData); pullErr != nil {
+			logger.NfmLog.Errorf("Drop urilist cleanup err: %+v", pullErr)
+		}
+		if factory.NrfConfig.GetOAuth() {
+			nfCertPath := oauth.GetNFCertPath(
+				factory.NrfConfig.GetCertBasePath(), string(profile.NfType), profile.NfInstanceId)
+			if removeErr := os.Remove(nfCertPath); removeErr != nil {
+				logger.NfmLog.Warningf("Can not delete NFCertPem file: %v: %v", nfCertPath, removeErr)
+			}
+		}
+	}
+}
+
+// touchLastHeartBeat records the contact the sweeps measure against. Stored
+// as fixed-width UTC RFC3339: $lt needs lexicographic order to match
+// chronological order, which fractional seconds or a zone offset would break.
+func touchLastHeartBeat(nfInstanceID string) error {
+	_, err := mongoapi.Client.Database(factory.NrfConfig.Configuration.MongoDBName).
+		Collection(nrf_context.NfProfileCollName).
+		UpdateOne(context.Background(),
+			bson.M{"nfInstanceId": nfInstanceID},
+			bson.M{"$set": bson.M{"lastHeartBeat": time.Now().UTC().Format(time.RFC3339)}})
+	return err
+}
+
+// clearSuspension moves a suspended instance back to REGISTERED. The status
+// filter makes racing the sweep safe in both orders.
+func clearSuspension(nfInstanceID string) error {
+	_, err := mongoapi.Client.Database(factory.NrfConfig.Configuration.MongoDBName).
+		Collection(nrf_context.NfProfileCollName).
+		UpdateOne(context.Background(),
+			bson.M{
+				"nfInstanceId": nfInstanceID,
+				"nfStatus":     string(models.NrfNfManagementNfStatus_SUSPENDED),
+			},
+			bson.M{"$set": bson.M{"nfStatus": string(models.NrfNfManagementNfStatus_REGISTERED)}})
+	return err
 }
 
 func (p *Processor) HandleNFDeregisterRequest(c *gin.Context, nfInstanceId string) {
@@ -353,8 +547,6 @@ func (p *Processor) NFDeregisterProcedure(nfInstanceID string) *models.ProblemDe
 			logger.NfmLog.Warningf("Can not delete NFCertPem file: %v: %v", nfCertPath, removeErr)
 		}
 	}
-	// Minus NF Register Conter
-	p.Context().DelNfRegister()
 	logger.NfmLog.Infof("NfDeregister Success: %v [%v]", nfInstanceType, nfInstanceID)
 	return nil
 }
@@ -441,12 +633,28 @@ func (p *Processor) UpdateNFInstanceProcedure(
 		}
 	}
 
+	// The NFUpdate is the heart-beat (TS 29.510 clause 5.2.2.3): stamp it
+	// before the patch stores REGISTERED, or a concurrent sweep could claim
+	// the instance on its stale timestamp and re-suspend it. Failures are
+	// logged; the next heart-beat retries.
+	if err = touchLastHeartBeat(nfInstanceID); err != nil {
+		logger.NfmLog.Errorf("UpdateNFInstanceProcedure record heart-beat err: %+v", err)
+	}
+
 	if err := mongoapi.RestfulAPIJSONPatch(collName, filter, patchJSON); err != nil {
 		logger.NfmLog.Errorf("UpdateNFInstanceProcedure err: %+v", err)
 		return nil, &models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
 			Detail: err.Error(),
+		}
+	}
+	// A load-only heart-beat is still a heart-beat (clause 5.2.2.3): an
+	// NFUpdate that does not write nfStatus itself lifts a suspension, or a
+	// suspended instance that keeps heart-beating would stay SUSPENDED forever.
+	if !nfStatusPatched(patchJSON) {
+		if err = clearSuspension(nfInstanceID); err != nil {
+			logger.NfmLog.Errorf("UpdateNFInstanceProcedure clear suspension err: %+v", err)
 		}
 	}
 
@@ -460,6 +668,19 @@ func (p *Processor) UpdateNFInstanceProcedure(
 			Cause:  "SYSTEM_FAILURE",
 		}
 	}
+	// The instance can be deregistered between the writes above and this read.
+	if nf == nil {
+		logger.NfmLog.Warnf("NFProfile[%s] not found", nfInstanceID)
+		return nil, &models.ProblemDetails{
+			Status: http.StatusNotFound,
+			Cause:  "RESOURCE_URI_STRUCTURE_NOT_FOUND",
+			Detail: fmt.Sprintf("NFProfile[%s] not found", nfInstanceID),
+		}
+	}
+
+	// Sweep bookkeeping, not part of the exposed NF profile.
+	delete(nf, "lastHeartBeat")
+	delete(nf, "suspendedAt")
 
 	nfProfilesRaw := []map[string]interface{}{
 		nf,
@@ -518,6 +739,11 @@ func validateNfProfilePatch(patchJSON []byte) error {
 		if normalizedPath == "/nfinstanceid" || strings.HasPrefix(normalizedPath, "/nfinstanceid/") {
 			return fmt.Errorf("nfInstanceId is immutable and cannot be modified")
 		}
+		// heartBeatTimer is ours to set (clause 5.2.2.3): NFs reset their ticker
+		// from the response, so patching it to 0 would self-suspend.
+		if normalizedPath == "/heartbeattimer" || strings.HasPrefix(normalizedPath, "/heartbeattimer/") {
+			return fmt.Errorf("heartBeatTimer is set by the NRF and cannot be modified")
+		}
 
 		from, ok := operation["from"].(string)
 		if !ok {
@@ -528,9 +754,42 @@ func validateNfProfilePatch(patchJSON []byte) error {
 		if normalizedFrom == "/nfinstanceid" || strings.HasPrefix(normalizedFrom, "/nfinstanceid/") {
 			return fmt.Errorf("nfInstanceId is immutable and cannot be modified")
 		}
+		if normalizedFrom == "/heartbeattimer" || strings.HasPrefix(normalizedFrom, "/heartbeattimer/") {
+			return fmt.Errorf("heartBeatTimer is set by the NRF and cannot be modified")
+		}
 	}
 
 	return nil
+}
+
+// nfStatusPatched reports whether the patch writes nfStatus itself: then the
+// status is the NF's explicit choice; otherwise the update is a pure
+// heart-beat and may clear a suspension. The empty path is the whole-document
+// pointer.
+//
+// The comparison is byte-exact, JSON Pointers are case-sensitive: a patch
+// naming /NfStatus writes a separate key and must still count as a plain
+// heart-beat. Unlike validateNfProfilePatch, normalizing here would suppress
+// a correction instead of merely rejecting more patches.
+func nfStatusPatched(patchJSON []byte) bool {
+	var operations []struct {
+		Op   string `json:"op"`
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(patchJSON, &operations); err != nil {
+		return false
+	}
+	for _, operation := range operations {
+		if operation.Op == "test" {
+			// test asserts and never writes (RFC 6902).
+			continue
+		}
+		switch operation.Path {
+		case "", "/nfStatus":
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Processor) GetNFInstanceProcedure(c *gin.Context, nfInstanceID string) {
@@ -550,6 +809,9 @@ func (p *Processor) GetNFInstanceProcedure(c *gin.Context, nfInstanceID string) 
 		util.GinProblemJson(c, problemDetails)
 		return
 	}
+	// Sweep bookkeeping, not part of the exposed NF profile.
+	delete(response, "lastHeartBeat")
+	delete(response, "suspendedAt")
 	c.JSON(http.StatusOK, response)
 }
 
@@ -651,6 +913,13 @@ func (p *Processor) NFRegisterProcedure(
 		return
 	}
 
+	// The heart-beat window opens at registration. Written beside the profile,
+	// not into putData, so it never leaks into the response bodies below.
+	// Failures are logged; the first heart-beat stamps the field anyway.
+	if err = touchLastHeartBeat(nfInstanceId); err != nil {
+		logger.NfmLog.Errorf("NFRegisterProcedure record heart-beat err: %+v", err)
+	}
+
 	if existed {
 		logger.NfmLog.Infoln("NFRegister NfProfile Update:", nfInstanceId)
 		uriList := nrf_context.GetNofificationUri(&nf)
@@ -683,9 +952,6 @@ func (p *Processor) NFRegisterProcedure(
 		// set info for NotificationData
 		Notification_event := models.NotificationEventType_REGISTERED
 		nfInstanceUri := locationHeaderValue
-
-		// Add NF Register Conter
-		p.Context().AddNfRegister()
 
 		for _, target := range uriList {
 			notifCtxCreate, pd := p.getNFNotifyCtx(target.TargetNf)

--- a/internal/sbi/processor/nf_management.go
+++ b/internal/sbi/processor/nf_management.go
@@ -231,7 +231,8 @@ func touchLastHeartBeat(nfInstanceID string) error {
 }
 
 // clearSuspension moves a suspended instance back to REGISTERED. The status
-// filter makes racing the sweep safe in both orders.
+// filter makes racing the sweep safe in both orders. suspendedAt goes with
+// it: the drop sweep must never see a stale stamp on a live instance.
 func clearSuspension(nfInstanceID string) error {
 	_, err := mongoapi.Client.Database(factory.NrfConfig.Configuration.MongoDBName).
 		Collection(nrf_context.NfProfileCollName).
@@ -240,7 +241,10 @@ func clearSuspension(nfInstanceID string) error {
 				"nfInstanceId": nfInstanceID,
 				"nfStatus":     string(models.NrfNfManagementNfStatus_SUSPENDED),
 			},
-			bson.M{"$set": bson.M{"nfStatus": string(models.NrfNfManagementNfStatus_REGISTERED)}})
+			bson.M{
+				"$set":   bson.M{"nfStatus": string(models.NrfNfManagementNfStatus_REGISTERED)},
+				"$unset": bson.M{"suspendedAt": ""},
+			})
 	return err
 }
 

--- a/internal/sbi/processor/nf_management_test.go
+++ b/internal/sbi/processor/nf_management_test.go
@@ -1,0 +1,127 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateNfProfilePatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		patch   string
+		wantErr string
+	}{
+		{
+			name:  "ordinary heart-beat",
+			patch: `[{"op":"replace","path":"/nfStatus","value":"REGISTERED"}]`,
+		},
+		{
+			name:  "load update",
+			patch: `[{"op":"replace","path":"/load","value":42}]`,
+		},
+		{
+			name:    "nfInstanceId is the resource identity",
+			patch:   `[{"op":"replace","path":"/nfInstanceId","value":"other"}]`,
+			wantErr: "nfInstanceId is immutable",
+		},
+		{
+			name:    "nfInstanceId reached through a subpath",
+			patch:   `[{"op":"remove","path":"/nfInstanceId/0"}]`,
+			wantErr: "nfInstanceId is immutable",
+		},
+		{
+			// We own the interval (TS 29.510 clause 5.2.2.3), and NFs reset their
+			// ticker from the response, so patching it to 0 would self-suspend.
+			name:    "heartBeatTimer belongs to the NRF",
+			patch:   `[{"op":"replace","path":"/heartBeatTimer","value":0}]`,
+			wantErr: "heartBeatTimer is set by the NRF",
+		},
+		{
+			name:    "copy source is checked too",
+			patch:   `[{"op":"copy","from":"/nfInstanceId","path":"/fqdn"}]`,
+			wantErr: "nfInstanceId is immutable",
+		},
+		{
+			name:    "mis-cased nfInstanceId is still rejected",
+			patch:   `[{"op":"replace","path":"/NfInstanceId","value":"other"}]`,
+			wantErr: "nfInstanceId is immutable",
+		},
+		{
+			name:    "mis-cased heartBeatTimer is still rejected",
+			patch:   `[{"op":"replace","path":"/HeartBeatTimer","value":0}]`,
+			wantErr: "heartBeatTimer is set by the NRF",
+		},
+		{
+			name:    "malformed payload",
+			patch:   `not json`,
+			wantErr: "invalid JSON Patch payload",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNfProfilePatch([]byte(tt.patch))
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestNfStatusPatched pins the byte-exact pointer comparison: "/NfStatus" is
+// a different JSON Pointer from "/nfStatus" (RFC 6901), so a patch naming it
+// must still count as a plain heart-beat.
+func TestNfStatusPatched(t *testing.T) {
+	tests := []struct {
+		name  string
+		patch string
+		want  bool
+	}{
+		{
+			name:  "explicit nfStatus is the NF's own choice",
+			patch: `[{"op":"replace","path":"/nfStatus","value":"UNDISCOVERABLE"}]`,
+			want:  true,
+		},
+		{
+			name:  "whole-document pointer rewrites nfStatus with everything else",
+			patch: `[{"op":"replace","path":"","value":{}}]`,
+			want:  true,
+		},
+		{
+			name:  "load-only heart-beat",
+			patch: `[{"op":"replace","path":"/load","value":42}]`,
+			want:  false,
+		},
+		{
+			name:  "mis-cased pointer names a different attribute",
+			patch: `[{"op":"add","path":"/NfStatus","value":"REGISTERED"}]`,
+			want:  false,
+		},
+		{
+			name:  "test op asserts, never writes",
+			patch: `[{"op":"test","path":"/nfStatus","value":"SUSPENDED"}]`,
+			want:  false,
+		},
+		{
+			name:  "test-guarded load update is still a pure heart-beat",
+			patch: `[{"op":"test","path":"/nfStatus","value":"SUSPENDED"},{"op":"replace","path":"/load","value":42}]`,
+			want:  false,
+		},
+		{
+			name:  "malformed patch",
+			patch: `not json`,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, nfStatusPatched([]byte(tt.patch)))
+		})
+	}
+}

--- a/internal/sbi/processor/nf_management_test.go
+++ b/internal/sbi/processor/nf_management_test.go
@@ -1,10 +1,14 @@
 package processor
 
 import (
+	"encoding/json"
 	"testing"
 
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/free5gc/openapi/models"
 )
 
 func TestValidateNfProfilePatch(t *testing.T) {
@@ -63,6 +67,68 @@ func TestValidateNfProfilePatch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateNfProfilePatch([]byte(tt.patch))
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestCheckPatchInvariants pins the whole-document escape: a root-pointer op
+// (path "", RFC 6901) never matches the path guards in validateNfProfilePatch,
+// so the applied result must be checked against the stored profile.
+func TestCheckPatchInvariants(t *testing.T) {
+	const original = `{"nfInstanceId":"nf-1","nfType":"AUSF","nfStatus":"REGISTERED","heartBeatTimer":10}`
+
+	tests := []struct {
+		name    string
+		patch   string
+		wantErr string
+	}{
+		{
+			name:  "ordinary heart-beat",
+			patch: `[{"op":"replace","path":"/nfStatus","value":"REGISTERED"}]`,
+		},
+		{
+			name: "root replace preserving the NRF-owned fields",
+			patch: `[{"op":"replace","path":"","value":` +
+				`{"nfInstanceId":"nf-1","nfType":"AMF","nfStatus":"UNDISCOVERABLE","heartBeatTimer":10}}]`,
+		},
+		{
+			name: "root replace renaming nfInstanceId",
+			patch: `[{"op":"replace","path":"","value":` +
+				`{"nfInstanceId":"other","nfType":"AUSF","nfStatus":"REGISTERED","heartBeatTimer":10}}]`,
+			wantErr: "nfInstanceId is immutable",
+		},
+		{
+			name: "root replace changing heartBeatTimer",
+			patch: `[{"op":"replace","path":"","value":` +
+				`{"nfInstanceId":"nf-1","nfType":"AUSF","nfStatus":"REGISTERED","heartBeatTimer":3600}}]`,
+			wantErr: "heartBeatTimer is set by the NRF",
+		},
+		{
+			name: "root replace dropping heartBeatTimer",
+			patch: `[{"op":"replace","path":"","value":` +
+				`{"nfInstanceId":"nf-1","nfType":"AUSF","nfStatus":"REGISTERED"}}]`,
+			wantErr: "heartBeatTimer is set by the NRF",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patch, err := jsonpatch.DecodePatch([]byte(tt.patch))
+			require.NoError(t, err)
+			patchedJSON, applyErr := patch.Apply([]byte(original))
+			require.NoError(t, applyErr)
+
+			var originalProfile, patchedProfile models.NrfNfManagementNfProfile
+			require.NoError(t, json.Unmarshal([]byte(original), &originalProfile))
+			require.NoError(t, json.Unmarshal(patchedJSON, &patchedProfile))
+
+			err = checkPatchInvariants(&originalProfile, &patchedProfile)
 			if tt.wantErr == "" {
 				assert.NoError(t, err)
 				return

--- a/pkg/factory/config.go
+++ b/pkg/factory/config.go
@@ -34,9 +34,13 @@ const (
 	NrfMetricsDefaultPort        = 9091
 	NrfMetricsDefaultScheme      = "https"
 	NrfMetricsDefaultNamespace   = "free5gc"
-	NrfNfmResUriPrefix           = "/nnrf-nfm/v1"
-	NrfDiscResUriPrefix          = "/nnrf-disc/v1"
-	NrfBootstrappingPrefix       = "/bootstrapping"
+	// Heart-beat defaults (TS 29.510 clause 5.2.2.3): the NRF owns the interval
+	// and suspends an instance after Timer * SuspendFactor seconds of silence.
+	NrfDefaultHeartbeatTimer         = 10
+	NrfDefaultHeartbeatSuspendFactor = 2
+	NrfNfmResUriPrefix               = "/nnrf-nfm/v1"
+	NrfDiscResUriPrefix              = "/nnrf-disc/v1"
+	NrfBootstrappingPrefix           = "/bootstrapping"
 )
 
 type Config struct {
@@ -55,6 +59,15 @@ func (c *Config) Validate() (bool, error) {
 		if result, err := configuration.validate(); err != nil {
 			return result, err
 		}
+		// A dropDelay at or below the suspension deadline would deregister
+		// instances the moment they are suspended. Unset (0) disables the drop
+		// sweep entirely, so only a configured value is checked.
+		if dropDelay := c.GetHeartbeatDropDelay(); dropDelay > 0 &&
+			dropDelay <= c.GetHeartbeatTimer()*c.GetHeartbeatSuspendFactor() {
+			return false, fmt.Errorf(
+				"heartbeat dropDelay (%ds) must exceed the suspension deadline timer*suspendFactor (%ds)",
+				dropDelay, c.GetHeartbeatTimer()*c.GetHeartbeatSuspendFactor())
+		}
 	}
 
 	result, err := govalidator.ValidateStruct(c)
@@ -72,8 +85,21 @@ type Configuration struct {
 	Metrics         *Metrics      `yaml:"metrics,omitempty" valid:"optional"`
 	MongoDBName     string        `yaml:"MongoDBName" valid:"required"`
 	MongoDBUrl      string        `yaml:"MongoDBUrl" valid:"required"`
+	Heartbeat       *Heartbeat    `yaml:"heartbeat,omitempty" valid:"optional"`
 	DefaultPlmnId   models.PlmnId `yaml:"DefaultPlmnId" valid:"required"`
 	ServiceNameList []string      `yaml:"serviceNameList,omitempty" valid:"required"`
+}
+
+// Heartbeat configures the NF Heart-Beat procedure (TS 29.510 clause 5.2.2.3).
+// Timer is the interval advertised on registration; an instance silent for
+// Timer * SuspendFactor seconds is SUSPENDED. Setting DropDelay additionally
+// deregisters instances that stay SUSPENDED for that many seconds; unset, the
+// NRF suspends but never deletes. An NF re-registers on a heart-beat 404, so a
+// live instance dropped by mistake comes back on its next heart-beat.
+type Heartbeat struct {
+	Timer         int `yaml:"timer,omitempty" valid:"optional,range(1|3600)"`
+	SuspendFactor int `yaml:"suspendFactor,omitempty" valid:"optional,range(2|10)"`
+	DropDelay     int `yaml:"dropDelay,omitempty" valid:"optional,range(60|604800)"`
 }
 
 type Logger struct {
@@ -510,4 +536,42 @@ func (c *Config) GetServiceNameList() []string {
 	c.RLock()
 	defer c.RUnlock()
 	return c.Configuration.ServiceNameList
+}
+
+// GetHeartbeatTimer returns the heart-beat interval in seconds advertised to
+// registering NFs. The NRF owns it (TS 29.510 clause 5.2.2.3); an NF cannot
+// negotiate it.
+func (c *Config) GetHeartbeatTimer() int {
+	c.RLock()
+	defer c.RUnlock()
+	if hb := c.Configuration.Heartbeat; hb != nil && hb.Timer > 0 {
+		return hb.Timer
+	}
+	return NrfDefaultHeartbeatTimer
+}
+
+// GetHeartbeatSuspendFactor returns how many intervals may be missed before
+// an instance is SUSPENDED. range(2|10) keeps the deadline longer than the
+// interval, as TS 29.510 clause 5.2.2.3 requires.
+func (c *Config) GetHeartbeatSuspendFactor() int {
+	c.RLock()
+	defer c.RUnlock()
+	if hb := c.Configuration.Heartbeat; hb != nil && hb.SuspendFactor > 0 {
+		return hb.SuspendFactor
+	}
+	return NrfDefaultHeartbeatSuspendFactor
+}
+
+// GetHeartbeatDropDelay returns how long, in seconds, an instance may stay
+// SUSPENDED before it is deregistered, or 0 when dropDelay is unset and
+// deregistration is disabled. Validate keeps a configured value above the
+// suspension deadline; beyond that, an NF re-registers on a heart-beat 404,
+// so a wrongly dropped instance recovers on its next heart-beat.
+func (c *Config) GetHeartbeatDropDelay() int {
+	c.RLock()
+	defer c.RUnlock()
+	if hb := c.Configuration.Heartbeat; hb != nil && hb.DropDelay > 0 {
+		return hb.DropDelay
+	}
+	return 0
 }

--- a/pkg/factory/config_test.go
+++ b/pkg/factory/config_test.go
@@ -1,0 +1,106 @@
+package factory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/free5gc/openapi/models"
+)
+
+func TestHeartbeatDefaults(t *testing.T) {
+	tests := []struct {
+		name              string
+		heartbeat         *Heartbeat
+		wantTimer         int
+		wantSuspendFactor int
+		wantDropDelay     int
+	}{
+		// A dropDelay of 0 means deregistration is disabled: unlike the other
+		// two fields it has no default, the drop sweep is opt-in.
+		{
+			"absent block", nil,
+			NrfDefaultHeartbeatTimer, NrfDefaultHeartbeatSuspendFactor, 0,
+		},
+		{
+			"empty block", &Heartbeat{},
+			NrfDefaultHeartbeatTimer, NrfDefaultHeartbeatSuspendFactor, 0,
+		},
+		{
+			"configured", &Heartbeat{Timer: 30, SuspendFactor: 3, DropDelay: 7200},
+			30, 3, 7200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Configuration: &Configuration{Heartbeat: tt.heartbeat}}
+			assert.Equal(t, tt.wantTimer, cfg.GetHeartbeatTimer())
+			assert.Equal(t, tt.wantSuspendFactor, cfg.GetHeartbeatSuspendFactor())
+			assert.Equal(t, tt.wantDropDelay, cfg.GetHeartbeatDropDelay())
+		})
+	}
+}
+
+// A heartbeat timer above 3600 must fail at config load: the profile
+// validator caps heartBeatTimer at 3600 and runs on the config-derived value
+// at every registration.
+func TestValidateHeartbeatRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		heartbeat *Heartbeat
+		wantErr   bool
+	}{
+		{"absent block", nil, false},
+		{"configured in range", &Heartbeat{Timer: 60, SuspendFactor: 3}, false},
+		{"timer at profile validator cap", &Heartbeat{Timer: 3600, DropDelay: 14400}, false},
+		{"timer above profile validator cap", &Heartbeat{Timer: 7200}, true},
+		{"suspend factor below lower bound", &Heartbeat{SuspendFactor: 1}, true},
+		{"suspend factor at upper bound", &Heartbeat{SuspendFactor: 10}, false},
+		{"suspend factor above upper bound", &Heartbeat{SuspendFactor: 11}, true},
+		{"drop delay in range", &Heartbeat{DropDelay: 7200}, false},
+		{"drop delay below range floor", &Heartbeat{DropDelay: 59}, true},
+		{"drop delay above range ceiling", &Heartbeat{DropDelay: 604801}, true},
+		// A dropDelay at or below the suspension deadline must fail at load, or
+		// instances would be deregistered the moment they are suspended.
+		{"drop delay at suspension deadline", &Heartbeat{Timer: 100, SuspendFactor: 5, DropDelay: 500}, true},
+		{"drop delay above suspension deadline", &Heartbeat{Timer: 100, SuspendFactor: 5, DropDelay: 501}, false},
+		// With dropDelay unset the drop sweep is off, so the cross-field check
+		// does not apply and any valid timer stands alone.
+		{"large timer with drop disabled", &Heartbeat{Timer: 3600}, false},
+		// The dropDelay range ceiling (604800) must leave valid choices above the
+		// largest possible suspension deadline (3600 * 10), or the extreme corner
+		// of the timer and suspendFactor ranges would be unsatisfiable.
+		{
+			"max deadline satisfiable within dropDelay range",
+			&Heartbeat{Timer: 3600, SuspendFactor: 10, DropDelay: 604800}, false,
+		},
+		{
+			"max deadline rejects in-range dropDelay below it",
+			&Heartbeat{Timer: 3600, SuspendFactor: 10, DropDelay: 36000}, true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Info: &Info{Version: "1.0.2"},
+				Configuration: &Configuration{
+					Sbi:             &Sbi{Scheme: "http", BindingIPv4: "127.0.0.1"},
+					MongoDBName:     "free5gc",
+					MongoDBUrl:      "mongodb://127.0.0.1:27017",
+					Heartbeat:       tt.heartbeat,
+					DefaultPlmnId:   models.PlmnId{Mcc: "208", Mnc: "93"},
+					ServiceNameList: []string{"nnrf-nfm", "nnrf-disc"},
+				},
+				Logger: &Logger{Level: "info"},
+			}
+			_, err := cfg.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -178,6 +178,9 @@ func (a *NrfApp) Start() {
 	a.wg.Add(1)
 	go a.listenShutdownEvent()
 
+	a.wg.Add(1)
+	go a.sweepStaleNfProfiles()
+
 	if err := a.sbiServer.Run(&a.wg); err != nil {
 		logger.MainLog.Fatalf("Run SBI server failed: %+v", err)
 	}
@@ -207,43 +210,62 @@ func (a *NrfApp) Terminate() {
 	a.cancel()
 }
 
+// sweepStaleNfProfiles runs the heart-beat sweeps once per heart-beat
+// interval: suspend instances silent past the suspension deadline, then,
+// when dropDelay is set and the startup grace has passed, deregister those
+// SUSPENDED past the drop delay. The database claims each instance for a
+// single replica, however many run.
+func (a *NrfApp) sweepStaleNfProfiles() {
+	defer a.wg.Done()
+
+	interval := time.Duration(a.cfg.GetHeartbeatTimer()) * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	start := time.Now()
+	for {
+		select {
+		case <-a.ctx.Done():
+			return
+		case <-ticker.C:
+			a.sweepOnce(time.Since(start))
+		}
+	}
+}
+
+// sweepOnce recovers per tick: a panic must not silently kill the sweeper.
+func (a *NrfApp) sweepOnce(uptime time.Duration) {
+	defer func() {
+		if p := recover(); p != nil {
+			logger.MainLog.Errorf("panic in heart-beat sweep: %v\n%s", p, string(debug.Stack()))
+		}
+	}()
+	a.processor.SuspendStaleNfProfiles(a.ctx)
+	// Suspending first is safe: a fresh suspendedAt is never past the drop
+	// cutoff.
+	if dropGraceElapsed(uptime, a.cfg.GetHeartbeatTimer(), a.cfg.GetHeartbeatSuspendFactor()) {
+		a.processor.DropStaleSuspendedNfProfiles(a.ctx)
+	}
+}
+
+// dropGraceElapsed keeps the drop sweep quiet right after startup: while the
+// NRF was down, live instances could not lift their suspension. One
+// suspension deadline plus one interval lets them heart-beat back first.
+func dropGraceElapsed(uptime time.Duration, timer, suspendFactor int) bool {
+	return uptime > time.Duration(timer*(suspendFactor+1))*time.Second
+}
+
+// terminateProcedure stops serving but leaves the registry untouched: a
+// terminating replica must not deregister the whole network. Dead instances
+// are handled by the heart-beat sweep, here or on another replica.
 func (a *NrfApp) terminateProcedure() {
 	logger.MainLog.Infof("Terminating NRF...")
-
-	waitTime := 5
-	logger.MainLog.Infof("Waiting for %vs for other NFs to deregister", waitTime)
-	a.waitNfDeregister(waitTime)
-
-	logger.MainLog.Infof("Remove NF Profile...")
-	err := mongoapi.Drop(nrf_context.NfProfileCollName)
-	if err != nil {
-		logger.MainLog.Errorf("Drop NfProfile collection failed: %+v", err)
-	}
 
 	a.sbiServer.Stop()
 
 	if a.metricsServer != nil {
 		a.metricsServer.Stop()
 		logger.MainLog.Infof("NRF Metrics Server terminated")
-	}
-}
-
-func (a *NrfApp) waitNfDeregister(waitTime int) {
-	ctx, cancal := context.WithTimeout(context.Background(), time.Duration(waitTime)*time.Second)
-	defer cancal()
-
-	ticker := time.NewTicker(100 * time.Millisecond)
-	for {
-		select {
-		case <-ctx.Done():
-			logger.MainLog.Warningln("Wait NF Deregister timeout")
-			return
-		case <-ticker.C:
-			if a.Context().NfRegistNum == 0 {
-				logger.MainLog.Infoln("All Register NF had been deregister")
-				return
-			}
-		}
 	}
 }
 

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 
 	nrf_context "github.com/free5gc/nrf/internal/context"
 	"github.com/free5gc/nrf/internal/logger"
@@ -175,6 +177,8 @@ func (a *NrfApp) Start() {
 
 	logger.InitLog.Infoln("Server starting")
 
+	a.createNfProfileIndexes()
+
 	a.wg.Add(1)
 	go a.listenShutdownEvent()
 
@@ -208,6 +212,21 @@ func (a *NrfApp) listenShutdownEvent() {
 
 func (a *NrfApp) Terminate() {
 	a.cancel()
+}
+
+// createNfProfileIndexes backs the heart-beat sweep queries, which otherwise
+// scan the collection on every claim. Creation is idempotent, and a missing
+// index only costs performance, so failures are logged and not fatal.
+func (a *NrfApp) createNfProfileIndexes() {
+	coll := mongoapi.Client.Database(factory.NrfConfig.Configuration.MongoDBName).
+		Collection(nrf_context.NfProfileCollName)
+	indexes := []mongo.IndexModel{
+		{Keys: bson.D{{Key: "nfStatus", Value: 1}, {Key: "lastHeartBeat", Value: 1}}},
+		{Keys: bson.D{{Key: "nfStatus", Value: 1}, {Key: "suspendedAt", Value: 1}, {Key: "lastHeartBeat", Value: 1}}},
+	}
+	if _, err := coll.Indexes().CreateMany(a.ctx, indexes); err != nil {
+		logger.InitLog.Warnf("Create NfProfile indexes failed: %+v", err)
+	}
 }
 
 // sweepStaleNfProfiles runs the heart-beat sweeps once per heart-beat

--- a/pkg/service/init_test.go
+++ b/pkg/service/init_test.go
@@ -1,0 +1,15 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDropGraceElapsed pins the boundary: with timer 10 and suspendFactor 2
+// the drop sweep stays quiet through the first 30 seconds.
+func TestDropGraceElapsed(t *testing.T) {
+	assert.False(t, dropGraceElapsed(30*time.Second, 10, 2))
+	assert.True(t, dropGraceElapsed(31*time.Second, 10, 2))
+}


### PR DESCRIPTION
Hello,

This PR is part of a series of PRs that will also modify the SBI NFs and the configuration file. The util PR adds the shared heart-beat runner those NFs use to answer the enforcement introduced here.

https://github.com/free5gc/util/pull/48
https://github.com/free5gc/ausf/pull/67

It addresses the following:
- On shutdown, the NRF drops the whole NfProfile collection, which does not behave well in a cloud setup
- The validityPeriod is hardcoded at 100s
- Enforcement of the heartBeatTimer and implementation of TS 29.510 clause 5.2.2.3 (Rel-18)

## Presentation of the changes

### NfProfile collection drop on shutdown

The NRF no longer touches the registry on shutdown: profiles outlive the process that accepted them, and with several replicas sharing one database, a single terminating pod must not deregister the whole network. Stale instances are handled by the heart-beat feature below instead. The registration counter that only served the shutdown wait (`NfRegistNum`, `AddNfRegister`, `DelNfRegister`, `waitNfDeregister`) goes with it.

### Validity Period

Discovery responses now advertise a validityPeriod of timer * suspendFactor instead of the hardcoded 100s, so a consumer honouring it stops caching results longer than the NRF can vouch for the instances' liveness.

### Heart-beat feature

The current behavior is to echo the heartBeatTimer back to the registering NF without enforcing it.

In a deployment scenario where an NF does not deregister properly and gets killed, we end up with stale profiles in the database. The 3GPP spec indicates that the NRF can set an NF's status to SUSPENDED when it has not been heard from within a configured period of time. Registration and every NFUpdate stamp a lastHeartBeat on the profile document. A sweeper ticks once per heart-beat interval and moves instances silent for timer * suspendFactor seconds to SUSPENDED, takes them out of discovery, and notifies their subscribers.

Each instance is claimed with an atomic findOneAndUpdate, so replicas sharing a database notify disjoint sets. The deadline uses the configured timer, never the stored profile's, which an NF could inflate.

Any heart-beat lifts a suspension, including a load-only NFUpdate that does not write nfStatus itself, or a suspended instance that kept heart-beating would stay SUSPENDED forever. The suspendedAt stamp is cleared with it, so the drop sweep never sees a stale stamp on a live instance.

Deregistration of suspended instances is opt-in, via dropDelay. When it is set and an NF stays SUSPENDED for more than dropDelay seconds, its profile is removed with the same effects as NFDeregister (notifications, urilist clean-up, OAuth cert removal). Since an NF started without a pinned nfInstanceId registers under a new one each boot, this is what keeps stale records from accumulating. When dropDelay is not set, the NRF suspends but never deletes.

Several guards keep the drop sweep from claiming a live instance: the delay counts from suspendedAt, an instance with a fresh lastHeartBeat is never claimed, findOneAndDelete claims atomically so subscribers hear DEREGISTERED once, and the sweep stays quiet for one suspension deadline plus one interval after startup, since while the NRF was down no instance could lift its suspension. Beyond that, an NF re-registers on a heart-beat 404, so an instance dropped while still alive is back in the registry on its next heart-beat.

- The NRF now owns the heart-beat interval: the registration response always carries the value the NRF enforces (configured or default), and registering NFs reset their timer from it. The NF's proposal is ignored, and a patch trying to set heartBeatTimer is rejected.
- The interval is re-stamped on every heart-beat. It is baked into the profile at registration while the sweeps use the current configuration, so lowering the timer would otherwise leave registered NFs ticking at the old interval and flapping into SUSPENDED.
- Discovery now excludes SUSPENDED instances at the query level.
- lastHeartBeat and suspendedAt are sweep bookkeeping and are stripped from the NFUpdate and NFGet responses.
- Both sweeps claim documents by nfStatus plus timestamp on every tick, so the two matching indexes are created at startup. Creation is idempotent and a missing index only costs performance, so a failure is logged and not fatal.

### Patch validation

`validateNfProfilePatch` guards paths, but a whole-document op (path `""`, RFC 6901) matches no path guard, so an NF could rename its own nfInstanceId or set its own heartBeatTimer through one. The applied result is now compared against the stored profile before it is persisted, and the update is rejected with a 400 when an NRF-owned field changed.

`UpdateNFInstanceProcedure` also answers 404 when the instance was deregistered between the patch write and the read-back, instead of failing on a nil document.

New configuration IE:

```yaml
heartbeat: # NF Heart-Beat procedure, refer to TS 29.510 clause 5.2.2.3
  timer: 10         # interval in seconds advertised to registering NFs (1~3600)
  suspendFactor: 2  # missed intervals before an instance is SUSPENDED (2~10)
  dropDelay: 3600   # opt-in: seconds in SUSPENDED before the profile is deregistered (60~604800)
```

The block itself can be omitted. timer and suspendFactor are optional and default to 10 and 2. dropDelay has no default: leaving it unset disables deregistration entirely. When set, config load rejects a value at or below timer * suspendFactor, since that would deregister instances the moment they are suspended.

## Testing

- Unit tests cover the patch validation rules (immutable nfInstanceId, NRF-owned heartBeatTimer, case normalization, copy source), the whole-document pointer invariants, the byte-exact nfStatusPatched classification, the config defaults and range/cross-field validation, and the startup grace boundary.
- The sweeps themselves are MongoDB-bound and have no unit coverage; verified manually against a local core: suspension after silence, discovery exclusion, recovery on the next heart-beat, and drop with DEREGISTERED notifications after the delay.

This work is sponsored by [Free Mobile](https://mobile.free.fr/)!
