### PR TITLE
fix: send NF status notifications to subscription callback URI

### DIFF
--- a/internal/sbi/consumer/nrf_service.go
+++ b/internal/sbi/consumer/nrf_service.go
@@ -76,7 +76,7 @@ func (s *nnrfService) SendNFStatusNotify(
 	}
 
 	_, err := client.SubscriptionsCollectionApi.CreateSubscriptionOnNFStatusEventPost(
-		ctx, nfInstanceUri, request)
+		ctx, url, request)
 	if err != nil {
 		logger.NfmLog.Infof("Notify fail: %v", err)
 		problemDetails := &models.ProblemDetails{


### PR DESCRIPTION
### **fix(nrf): send NF status notifications to subscription callback URI (#1141)**

- This PR fixes issue #1141 in NRF NF status notification delivery.
  It sends notifications to the subscriber-provided `nfStatusNotificationUri`.

- Root cause:
  - `SendNFStatusNotify` created the client with the callback URI, but passed
    `nfInstanceUri` to `CreateSubscriptionOnNFStatusEventPost`.
  - NRF therefore posted notifications to the NF instance NFM resource instead
    of the subscriber callback endpoint.

- Changes:
  - Use the subscription callback URI as the notification request target.

- This is reported in [GitHub Issue #1141](https://github.com/free5gc/free5gc/issues/1141).