### PR TITLE
fix: subscription condition mongodb filters

### DIFF
--- a/internal/context/management_data.go
+++ b/internal/context/management_data.go
@@ -522,24 +522,20 @@ func nnrfUriList(originalUL *UriList, ul *UriList, location []string) {
 	ul.Link = *links
 }
 
-func GetNofificationUri(nfProfile *models.NrfNfManagementNfProfile) []NotificationTarget {
-	var uriList []NotificationTarget
+func getNotificationFilters(nfProfile *models.NrfNfManagementNfProfile) []bson.M {
+	var filters []bson.M
 
 	// nfTypeCond
 	nfTypeCond := bson.M{
-		"subscrCond": bson.M{
-			"nfType": nfProfile.NfType,
-		},
+		"subscrCond.nfType": nfProfile.NfType,
 	}
-	setUriListByFilter(nfTypeCond, &uriList)
+	filters = append(filters, nfTypeCond)
 
 	// NfInstanceIdCond
 	nfInstanceIDCond := bson.M{
-		"subscrCond": bson.M{
-			"nfInstanceId": nfProfile.NfInstanceId,
-		},
+		"subscrCond.nfInstanceId": nfProfile.NfInstanceId,
 	}
-	setUriListByFilter(nfInstanceIDCond, &uriList)
+	filters = append(filters, nfInstanceIDCond)
 
 	// ServiceNameCond
 	if nfProfile.NfServices != nil {
@@ -553,18 +549,16 @@ func GetNofificationUri(nfProfile *models.NrfNfManagementNfProfile) []Notificati
 				"$in": serviceNames,
 			},
 		}
-		setUriListByFilter(ServiceNameCond, &uriList)
+		filters = append(filters, ServiceNameCond)
 	}
 
 	// AmfCond
 	if nfProfile.AmfInfo != nil {
 		amfCond := bson.M{
-			"subscrCond": bson.M{
-				"amfSetId":    nfProfile.AmfInfo.AmfSetId,
-				"amfRegionId": nfProfile.AmfInfo.AmfRegionId,
-			},
+			"subscrCond.amfSetId":    nfProfile.AmfInfo.AmfSetId,
+			"subscrCond.amfRegionId": nfProfile.AmfInfo.AmfRegionId,
 		}
-		setUriListByFilter(amfCond, &uriList)
+		filters = append(filters, amfCond)
 	}
 
 	// GuamiListCond
@@ -583,13 +577,14 @@ func GetNofificationUri(nfProfile *models.NrfNfManagementNfProfile) []Notificati
 					logger.NfmLog.Error(err)
 				}
 
-				guamiListBsonArray = append(guamiListBsonArray, bson.M{"subscrCond": bson.M{"$elemMatch": guamiMarshal}})
+				guamiListBsonArray = append(guamiListBsonArray,
+					bson.M{"subscrCond.guamiList": bson.M{"$elemMatch": guamiMarshal}})
 			}
 			guamiListFilter = bson.M{
 				"$or": guamiListBsonArray,
 			}
 		}
-		setUriListByFilter(guamiListFilter, &uriList)
+		filters = append(filters, guamiListFilter)
 	}
 
 	// NetworkSliceCond
@@ -607,7 +602,8 @@ func GetNofificationUri(nfProfile *models.NrfNfManagementNfProfile) []Notificati
 				logger.NfmLog.Error(err)
 			}
 
-			snssaisBsonArray = append(snssaisBsonArray, bson.M{"subscrCond": bson.M{"$elemMatch": snssaiMarshal}})
+			snssaisBsonArray = append(snssaisBsonArray,
+				bson.M{"subscrCond.snssaiList": bson.M{"$elemMatch": snssaiMarshal}})
 		}
 
 		var nsiListBsonArray bson.A
@@ -639,36 +635,38 @@ func GetNofificationUri(nfProfile *models.NrfNfManagementNfProfile) []Notificati
 				},
 			}
 		}
-		setUriListByFilter(networkSliceFilter, &uriList)
+		filters = append(filters, networkSliceFilter)
 	}
 
 	// NfGroupCond
 	if nfProfile.UdrInfo != nil {
 		nfGroupCond := bson.M{
-			"subscrCond": bson.M{
-				"nfType":    nfProfile.NfType,
-				"nfGroupId": nfProfile.UdrInfo.GroupId,
-			},
+			"subscrCond.nfType":    nfProfile.NfType,
+			"subscrCond.nfGroupId": nfProfile.UdrInfo.GroupId,
 		}
-		setUriListByFilter(nfGroupCond, &uriList)
+		filters = append(filters, nfGroupCond)
 	} else if nfProfile.UdmInfo != nil {
 		nfGroupCond := bson.M{
-			"subscrCond": bson.M{
-				"nfType":    nfProfile.NfType,
-				"nfGroupId": nfProfile.UdmInfo.GroupId,
-			},
+			"subscrCond.nfType":    nfProfile.NfType,
+			"subscrCond.nfGroupId": nfProfile.UdmInfo.GroupId,
 		}
-		setUriListByFilter(nfGroupCond, &uriList)
+		filters = append(filters, nfGroupCond)
 	} else if nfProfile.AusfInfo != nil {
 		nfGroupCond := bson.M{
-			"subscrCond": bson.M{
-				"nfType":    nfProfile.NfType,
-				"nfGroupId": nfProfile.AusfInfo.GroupId,
-			},
+			"subscrCond.nfType":    nfProfile.NfType,
+			"subscrCond.nfGroupId": nfProfile.AusfInfo.GroupId,
 		}
-		setUriListByFilter(nfGroupCond, &uriList)
+		filters = append(filters, nfGroupCond)
 	}
 
+	return filters
+}
+
+func GetNotificationUri(nfProfile *models.NrfNfManagementNfProfile) []NotificationTarget {
+	var uriList []NotificationTarget
+	for _, filter := range getNotificationFilters(nfProfile) {
+		setUriListByFilter(filter, &uriList)
+	}
 	return uriList
 }
 

--- a/internal/sbi/processor/nf_management.go
+++ b/internal/sbi/processor/nf_management.go
@@ -317,7 +317,7 @@ func (p *Processor) NFDeregisterProcedure(nfInstanceID string) *models.ProblemDe
 		return problemDetails
 	}
 
-	uriList := nrf_context.GetNofificationUri(&nfProfiles[0])
+	uriList := nrf_context.GetNotificationUri(&nfProfiles[0])
 	nfInstanceType := nfProfiles[0].NfType
 	nfInstanceUri := nrf_context.GetNfInstanceURI(nfInstanceID)
 	// set info for NotificationData
@@ -485,7 +485,7 @@ func (p *Processor) UpdateNFInstanceProcedure(
 		}
 	}
 
-	uriList := nrf_context.GetNofificationUri(&nfProfiles[0])
+	uriList := nrf_context.GetNotificationUri(&nfProfiles[0])
 
 	// set info for NotificationData
 	Notification_event := models.NotificationEventType_PROFILE_CHANGED
@@ -653,7 +653,7 @@ func (p *Processor) NFRegisterProcedure(
 
 	if existed {
 		logger.NfmLog.Infoln("NFRegister NfProfile Update:", nfInstanceId)
-		uriList := nrf_context.GetNofificationUri(&nf)
+		uriList := nrf_context.GetNotificationUri(&nf)
 
 		// set info for NotificationData
 		Notification_event := models.NotificationEventType_PROFILE_CHANGED
@@ -679,7 +679,7 @@ func (p *Processor) NFRegisterProcedure(
 		return
 	} else { // Create NF Profile case
 		logger.NfmLog.Infoln("Create NF Profile:", nfInstanceId)
-		uriList := nrf_context.GetNofificationUri(&nf)
+		uriList := nrf_context.GetNotificationUri(&nf)
 		// set info for NotificationData
 		Notification_event := models.NotificationEventType_REGISTERED
 		nfInstanceUri := locationHeaderValue


### PR DESCRIPTION
### **fix: correct NRF subscription condition filters (#1142)**

- Root cause:
  - `GetNotificationUri` queried `subscrCond` as a complete BSON subdocument.
  - Stored subscription conditions include default fields, so MongoDB exact
    subdocument matching did not find valid subscriptions.
  - GUAMI and SNSSAI conditions applied `$elemMatch` to `subscrCond` instead
    of their respective list fields.

- Changes:
  - Use dotted BSON paths when querying subscription condition fields.
  - Apply `$elemMatch` to `subscrCond.guamiList` and
    `subscrCond.snssaiList`.
  - Rename `GetNofificationUri` to `GetNotificationUri`.

This is reported in [GitHub Issue #1142](https://github.com/free5gc/free5gc/issues/1142).